### PR TITLE
[monitoring] Add nonoperational storage class alert 

### DIFF
--- a/monitoring/prometheus-rules/storage-class.yaml
+++ b/monitoring/prometheus-rules/storage-class.yaml
@@ -18,3 +18,20 @@
           The list of outdated storage classes can be obtained through
           
           `kubectl get sc -l storage.deckhouse.io/managed-by!=sds-replicated-volume`
+          
+    - alert: StorageClassIsNonOperational
+      expr: sum(kube_storageclass_info{provisioner='linstor.csi.linbit.com'} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_nonoperational=''}) > 0
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__storage_class_health: "NonOperationalStorageClass,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__storage_class_health: "NonOperationalStorageClass,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: Storage class is nonoperational
+        description: |
+          Failed to create a PV in one or more Storage Classes. It is necessary to check and determine the cause. You can obtain a list of Storage Classes by using the command:
+          
+          `kubectl get sc -l storage.deckhouse.io/nonOperational=""`


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added nonoperational storage class alert

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This is important alert to keep cluster operational

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Storage class operational status monitoring

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
