### PR TITLE
[linstor] Add "linstor resource-definition delete" command

### DIFF
--- a/images/linstor-server/client-wrapper.sh
+++ b/images/linstor-server/client-wrapper.sh
@@ -32,6 +32,7 @@ if [[ -z "$1" || "--help" == "$1" || "-h" == "$1" ]]; then
   echo "- error-reports list/show"
   echo "- controller version"
   echo "- advise resource/maintainance"
+  echo "- resource-definition delete"
   exit 0
 fi
 
@@ -48,6 +49,11 @@ done
 
 # Temporarily allow linstor node lost
 if [[ "$1" == "node" ]] && [[ "$2" == "lost" ]]; then
+  allowed=true
+fi
+
+# Allow linstor resource-definition delete
+if [[ "$1" == "resource-definition" ]] && [[ "$2" == "delete" ]]; then
   allowed=true
 fi
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

In this PR, we add the `linstor resource-definition delete` command to the list of allowed commands. This enhancement provides users with the capability to manually delete resources from **LINSTOR**, especially useful in scenarios where the **StorageClass's** `RECLAIMPOLICY` is set to `Retain`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Enables user-driven resource cleanup in **LINSTOR**, crucial for managing storage efficiently when auto-deletion is bypassed by a Retain reclaim policy.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Users gain control over storage resource lifecycle, ensuring optimal utilization and management within **LINSTOR** environments.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
