### PR TITLE
[monitoring] Fix label for nonoperational storage class

### DIFF
--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_watcher.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_watcher.go
@@ -257,7 +257,7 @@ func setNonOperationalLabelOnStorageClass(ctx context.Context, cl client.Client,
 		sc.Labels = make(map[string]string)
 	}
 
-	sc.Labels[label] = ""
+	sc.Labels[label] = "true"
 
 	err = cl.Update(ctx, sc)
 	if err != nil {

--- a/monitoring/prometheus-rules/storage-class.yaml
+++ b/monitoring/prometheus-rules/storage-class.yaml
@@ -20,7 +20,7 @@
           `kubectl get sc -l storage.deckhouse.io/managed-by!=sds-replicated-volume`
           
     - alert: StorageClassIsNonOperational
-      expr: sum(kube_storageclass_info{provisioner='linstor.csi.linbit.com'} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_nonoperational=''}) > 0
+      expr: sum(kube_storageclass_info{provisioner='linstor.csi.linbit.com'} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_nonoperational='true'}) > 0
       for: 5m
       labels:
         severity_level: "4"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix label for nonoperational storage class

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Now we have false positive alert

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct alert work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
