### PR TITLE
[monitoring] fix storage class is not managed through ReplicatedStorageClass alert

### DIFF
--- a/monitoring/prometheus-rules/storage-class.yaml
+++ b/monitoring/prometheus-rules/storage-class.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.replicated.storage_class
   rules:
-    - alert: ReplicatedPoolIsNotManagedThroughReplicatedStorageClass
+    - alert: StorageClassIsNotManagedThroughReplicatedStorageClass
       expr: sum(kube_storageclass_info{provisioner='linstor.csi.linbit.com'} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_managed_by!='sds-replicated-volume'}) > 0
       for: 5m
       labels:
@@ -11,7 +11,7 @@
         plk_protocol_version: "1"
         plk_create_group_if_not_exists__d8_drbd_device_health: "D8ReplicatedOutdatedPool,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__d8_drbd_device_health: "D8ReplicatedOutdatedPool,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        summary: Replicated pool is not managed through ReplicatedStorageClass
+        summary: Storage class is not managed through ReplicatedStorageClass
         description: |
           There are storage classes in the cluster that are not managed through ReplicatedStorageClass objects, but manually. 
           It is necessary to migrate from them to storage classes that are managed through ReplicatedStorageClass. 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix in storage class is not managed through ReplicatedStorageClass alert

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Now there is a misprint in alert name

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct alert

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
