### PR TITLE
[linstor] Patch CSI to 1.5.0-2-g16c206a: Prevent Node Reboots on Volume Deletion

### DIFF
--- a/images/linstor-csi/Dockerfile
+++ b/images/linstor-csi/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_UBUNTU=registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
-ARG BASE_GOLANG_19_BULLSEYE=registry.deckhouse.io/base_images/golang:1.19.3-bullseye@sha256:3d68e9eabd09f01f5851297902f2756ee2456a2e28b212e553315a3ddfcffe4b
+ARG BASE_GOLANG_21_BULLSEYE=registry.deckhouse.io/base_images/golang:1.21.6-bullseye@sha256:a363973b58d4d5a91d6e8f700c847e87c1143459e55464fefca9e6135358af98
 
-FROM $BASE_GOLANG_19_BULLSEYE as builder
+FROM $BASE_GOLANG_21_BULLSEYE as builder
 ARG LINSTOR_CSI_GITREPO=https://github.com/linbit/linstor-csi
 ARG LINSTOR_CSI_VERSION=1.5.0-2-g16c206a
 

--- a/images/linstor-csi/Dockerfile
+++ b/images/linstor-csi/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_GOLANG_19_BULLSEYE=registry.deckhouse.io/base_images/golang:1.19.3-bull
 
 FROM $BASE_GOLANG_19_BULLSEYE as builder
 ARG LINSTOR_CSI_GITREPO=https://github.com/linbit/linstor-csi
-ARG LINSTOR_CSI_VERSION=1.2.3
+ARG LINSTOR_CSI_VERSION=1.5.0-2-g16c206a
 
 # Copy patches
 COPY ./patches /patches


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR integrates a patch in the LINSTOR CSI driver, version `1.5.0-2-g16c206a`, specifically designed to modify the deletion process of volume definitions. This adjustment is implemented as a temporary solution to prevent node reboots that have been occurring during volume deletion, suspected to be related to an unresolved issue in DRBD 9.2. By altering the sequence of actions during volume deletion — delaying the removal of volume definitions until after all associated resources have been successfully deleted — we ensure that DRBD has completely shut down the resource, thereby avoiding the triggering condition for node reboots.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The deletion of volume definitions as an initial step in the volume removal process has been identified as a potential trigger for a bug in DRBD 9.2, leading to unwanted node reboots. Until the underlying issue in DRBD is identified and resolved, this patch serves as a crucial workaround by rearranging the deletion order, ensuring the stability and reliability of the system during volume deletion operations.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Prevention of unintended node reboots during the volume deletion process by addressing a suspected DRBD 9.2 bug.
- Enhanced system stability and reliability, ensuring uninterrupted service and data integrity.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
