### PR TITLE
[controller] Add age field

### DIFF
--- a/crds/replicatedstorageclass.yaml
+++ b/crds/replicatedstorageclass.yaml
@@ -175,3 +175,7 @@ spec:
           name: Reason
           type: string
           priority: 1
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+          description: The age of this resource

--- a/crds/replicatedstoragepool.yaml
+++ b/crds/replicatedstoragepool.yaml
@@ -93,3 +93,7 @@ spec:
           name: Reason
           type: string
           priority: 1
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+          description: The age of this resource


### PR DESCRIPTION
## Description

Add age field for custom resource definitions.

## Why do we need it, and what problem does it solve?

Provides more detailed output of replicatedstoragepool & replicatedstorageclass

## What is the expected result?

Age field present in i.e. kubectl get {rsp | rsc}

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
