### PR TITLE
[linstor] Add liveness probe for linstor-node

### DIFF
--- a/images/linstor-server/Dockerfile
+++ b/images/linstor-server/Dockerfile
@@ -212,9 +212,11 @@ EXPOSE 3366/tcp 3367/tcp
 RUN curl -Lfo /usr/bin/piraeus-entry.sh ${PIRAEUS_GITREPO}/raw/${PIRAEUS_COMMIT_REF}/dockerfiles/piraeus-server/entry.sh \
  && chmod +x /usr/bin/piraeus-entry.sh
 
-# Add liveness probe script
+# Add liveness probe scripts
 COPY liveness.sh /liveness.sh
+COPY liveness-satellite.sh /liveness-satellite.sh
 RUN chmod 755 /liveness.sh
+RUN chmod 755 /liveness-satellite.sh
 
 # Add wrapper for linstor client with only allowed commands
 COPY client-wrapper.sh /usr/local/bin/linstor

--- a/images/linstor-server/liveness-satellite.sh
+++ b/images/linstor-server/liveness-satellite.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2023 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/linstor-server/liveness-satellite.sh
+++ b/images/linstor-server/liveness-satellite.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sometimes nodes can be shown as Online without established connection to them.
+# This is a workaround for https://github.com/LINBIT/linstor-server/issues/331, https://github.com/LINBIT/linstor-server/issues/219
+
+# Check if there are symptoms of lost connection in linstor controller logs
+if test -f "/var/log/linstor-controller/linstor-Satellite.log"; then
+  if [ $(tail -n 1000 /var/log/linstor-controller/linstor-Satellite.log | grep 'Target decrypted buffer is too small' | wc -l) -ne 0 ]; then
+    exit 1
+  fi
+fi
+
+# Because shell keeps last exit code, we must force exit with code 0. If not, we will have exit code 1 because of grep, that not founded anything
+exit 0

--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -124,6 +124,14 @@ spec:
           - containerPort: 3367
             hostPort: 3367
             protocol: TCP
+        livenessProbe:
+          exec:
+            command:
+            - ./liveness-satellite.sh
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add satellite liveness probe

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Sometimes we have problem with satellites stucks, when binary is alive, but not serving connections at all

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Satellite restarts automatically if stuck

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
