### PR TITLE
[controller] Fix a bug with a linstor node address

### DIFF
--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_node.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_node.go
@@ -47,6 +47,8 @@ const (
 	LinstorEncryptionType     = "SSL" // "Plain"
 	reachableTimeout          = 10 * time.Second
 	DRBDNodeSelectorKey       = "storage.deckhouse.io/sds-replicated-volume-node"
+
+	InternalIP = "InternalIP"
 )
 
 var (
@@ -291,13 +293,20 @@ func CreateDRBDNode(
 	selectedKubernetesNode v1.Node,
 	drbdNodeProperties map[string]string,
 ) error {
+	var internalAddress string
+	for _, ad := range selectedKubernetesNode.Status.Addresses {
+		if ad.Type == InternalIP {
+			internalAddress = ad.Address
+		}
+	}
+
 	newLinstorNode := lclient.Node{
 		Name: selectedKubernetesNode.Name,
 		Type: LinstorSatelliteType,
 		NetInterfaces: []lclient.NetInterface{
 			{
 				Name:                    "default",
-				Address:                 net.ParseIP(selectedKubernetesNode.Status.Addresses[0].Address),
+				Address:                 net.ParseIP(internalAddress),
 				IsActive:                true,
 				SatellitePort:           LinstorNodePort,
 				SatelliteEncryptionType: LinstorEncryptionType,


### PR DESCRIPTION
Signed-off-by: Viktor Kramarenko <viktor.kramarenko@flant.com>

## Description
Made the new linstor node's address based on a node's InternalIP one.

## Why do we need it, and what problem does it solve?
Sometimes it chooses wrong IP address for a linstor node due to hardcore index.

## What is the expected result?
A new linstor node will choose the IP only from node's InternalIP type address.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
