### PR TITLE
[bashible] Add check if /etc/modules file exists

### DIFF
--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -56,7 +56,9 @@ spec:
 
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
-        sed -i 's/^drbd$//' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          sed -i 's/^drbd$//' /etc/modules
+        fi
         rmmod drbd_transport_rdma || true
         rmmod drbd_transport_tcp || true
         rmmod drbd || true
@@ -105,8 +107,10 @@ spec:
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
       else
-        if grep -q -E '^drbd$' /etc/modules; then
-          sed -i '/^drbd$/d' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          if grep -q -E '^drbd$' /etc/modules; then
+            sed -i '/^drbd$/d' /etc/modules
+          fi
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
 
@@ -163,8 +167,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    if grep -q -E '^drbd$' /etc/modules; then
-      sed -i '/^drbd$/d' /etc/modules
+    if [ -e "/etc/modules" ]; then
+      if grep -q -E '^drbd$' /etc/modules; then
+        sed -i '/^drbd$/d' /etc/modules
+      fi
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod

--- a/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -56,7 +56,9 @@ spec:
 
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
-        sed -i 's/^drbd$//' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          sed -i 's/^drbd$//' /etc/modules
+        fi
         rmmod drbd_transport_rdma || true
         rmmod drbd_transport_tcp || true
         rmmod drbd || true
@@ -110,8 +112,10 @@ spec:
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
       else
-        if grep -q -E '^drbd$' /etc/modules; then
-          sed -i '/^drbd$/d' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          if grep -q -E '^drbd$' /etc/modules; then
+            sed -i '/^drbd$/d' /etc/modules
+          fi
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
 
@@ -168,8 +172,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/${kernel_version_in_use}/kernel/drivers/
-    if grep -q -E '^drbd$' /etc/modules; then
-      sed -i '/^drbd$/d' /etc/modules
+    if [ -e "/etc/modules" ]; then
+      if grep -q -E '^drbd$' /etc/modules; then
+        sed -i '/^drbd$/d' /etc/modules
+      fi
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -56,7 +56,9 @@ spec:
 
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
-        sed -i 's/^drbd$//' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          sed -i 's/^drbd$//' /etc/modules
+        fi
         rmmod drbd_transport_rdma || true
         rmmod drbd_transport_tcp || true
         rmmod drbd || true
@@ -107,8 +109,10 @@ spec:
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
       else
-        if grep -q -E '^drbd$' /etc/modules; then
-          sed -i '/^drbd$/d' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          if grep -q -E '^drbd$' /etc/modules; then
+            sed -i '/^drbd$/d' /etc/modules
+          fi
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
 
@@ -165,8 +169,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    if grep -q -E '^drbd$' /etc/modules; then
-      sed -i '/^drbd$/d' /etc/modules
+    if [ -e "/etc/modules" ]; then
+      if grep -q -E '^drbd$' /etc/modules; then
+        sed -i '/^drbd$/d' /etc/modules
+      fi
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add check if /etc/modules file exists

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Bashible crashes if no /etc/modules file on node

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct bashible work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
