### PR TITLE
[linstor] Patch CSI to 98544cadb6d111d27a86a11ec07de91b99704b82: Prevent Node Reboots on Volume Deletion

### DIFF
--- a/images/linstor-csi/Dockerfile
+++ b/images/linstor-csi/Dockerfile
@@ -3,14 +3,14 @@ ARG BASE_GOLANG_21_BULLSEYE=registry.deckhouse.io/base_images/golang:1.21.6-bull
 
 FROM $BASE_GOLANG_21_BULLSEYE as builder
 ARG LINSTOR_CSI_GITREPO=https://github.com/linbit/linstor-csi
-ARG LINSTOR_CSI_VERSION=1.5.0-2-g16c206a
+ARG LINSTOR_CSI_VERSION=98544cadb6d111d27a86a11ec07de91b99704b82
 
 # Copy patches
 COPY ./patches /patches
 
 RUN git clone ${LINSTOR_CSI_GITREPO} /usr/local/go/linstor-csi/ \
  && cd /usr/local/go/linstor-csi \
- && git reset --hard v${LINSTOR_CSI_VERSION} \
+ && git reset --hard ${LINSTOR_CSI_VERSION} \
  && git apply /patches/*.patch \
  && cd cmd/linstor-csi \
  && go build -ldflags="-X github.com/piraeusdatastore/linstor-csi/pkg/driver.Version=v${LINSTOR_CSI_VERSION}" \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

After merging [PR #78](https://github.com/deckhouse/sds-replicated-volume/pull/78) to fix node reboots during volume deletions, we found that the CSI driver version `1.5.0-2-g16c206a` was removed by its developers as it was temporary. A new release including the necessary changes has not yet been created.

To ensure continuity and stability in our system, this PR temporarily shifts CSI driver to a specific commit `98544cadb6d111d27a86a11ec07de91b99704b82` that contains the critical fixes for the node reboot issue. This approach will be utilized until an official release incorporating these changes is available.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

By directly referencing the commit that includes the fixes, we can continue to benefit from these essential changes without waiting for a official release.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Prevention of unintended node reboots during volume deletion by applying the necessary patches from commit `98544cadb6d111d27a86a11ec07de91b99704b82`.
- Assurance of system stability and reliability until the changes are officially released in a new version of the CSI driver.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
