### PR TITLE
[docs] Actual typo lvmVolumeGroups and thinPoolName in examples

### DIFF
--- a/crds/doc-ru-replicatedstoragepool.yaml
+++ b/crds/doc-ru-replicatedstoragepool.yaml
@@ -23,7 +23,7 @@ spec:
                       name:
                         description: |
                           Имя ресурса LVMVolumeGroup.
-                      thinpoolname:
+                      thinPoolName:
                         description: |
                           Имя выбранного Thin-pool в рамках указанного LVMVolumeGroup. Обязательное поле если вы создаёте ReplicatedStoragePool с типом LVMThin.
             status:

--- a/docs/README.md
+++ b/docs/README.md
@@ -184,7 +184,7 @@ metadata:
   name: data
 spec:
   type: LVM
-  lvmvolumegroups: # Here, specify the names of the LvmVolumeGroup resources you created earlier
+  lvmVolumeGroups: # Here, specify the names of the LvmVolumeGroup resources you created earlier
     - name: vg-1-on-worker-0
     - name: vg-1-on-worker-1
     - name: vg-1-on-worker-2

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -184,7 +184,7 @@ metadata:
   name: data
 spec:
   type: LVM
-  lvmvolumegroups: # Здесь указываем имена ресурсов LvmVolumeGroup, которые мы создавали ранее
+  lvmVolumeGroups: # Здесь указываем имена ресурсов LvmVolumeGroup, которые мы создавали ранее
     - name: vg-1-on-worker-0
     - name: vg-1-on-worker-1
     - name: vg-1-on-worker-2

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -35,7 +35,7 @@ metadata:
   name: data
 spec:
   type: LVM
-  lvmvolumegroups:
+  lvmVolumeGroups:
     - name: lvg-1
     - name: lvg-2
 ```
@@ -49,7 +49,7 @@ metadata:
   name: thin-data
 spec:
   type: LVMThin
-  lvmvolumegroups:
+  lvmVolumeGroups:
     - name: lvg-3
       thinpoolname: thin-pool
     - name: lvg-4

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,9 +51,9 @@ spec:
   type: LVMThin
   lvmVolumeGroups:
     - name: lvg-3
-      thinpoolname: thin-pool
+      thinPoolName: thin-pool
     - name: lvg-4
-      thinpoolname: thin-pool
+      thinPoolName: thin-pool
 ```
 
 > **Caution!** All `LVMVolumeGroup` resources in the `spec` of the `ReplicatedStoragePool` resource must reside on different nodes. (You may not refer to multiple `LVMVolumeGroup` resources located on the same node).

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -35,7 +35,7 @@ metadata:
   name: data
 spec:
   type: LVM
-  lvmvolumegroups:
+  lvmVolumeGroups:
     - name: lvg-1
     - name: lvg-2
 ```
@@ -49,7 +49,7 @@ metadata:
   name: thin-data
 spec:
   type: LVMThin
-  lvmvolumegroups:
+  lvmVolumeGroups:
     - name: lvg-3
       thinpoolname: thin-pool
     - name: lvg-4

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -51,9 +51,9 @@ spec:
   type: LVMThin
   lvmVolumeGroups:
     - name: lvg-3
-      thinpoolname: thin-pool
+      thinPoolName: thin-pool
     - name: lvg-4
-      thinpoolname: thin-pool
+      thinPoolName: thin-pool
 ```
 
 > Внимание! Все ресурсы `LVMVolumeGroup`, указанные в `spec` ресурса `ReplicatedStoragePool`, должны быть на разных узлах. (Запрещено указывать несколько ресурсов `LVMVolumeGroup`, которые расположены на одном и том же узле).


### PR DESCRIPTION
## Description
Actual typo `lvmVolumeGroups` and `thinPoolName` in examples

## Why do we need it, and what problem does it solve?
Fix https://github.com/deckhouse/sds-replicated-volume/issues/86

## What is the expected result?
Correct documentation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
