### PR TITLE
[linstor] Fix path in liveness-satellite

### DIFF
--- a/images/linstor-server/liveness-satellite.sh
+++ b/images/linstor-server/liveness-satellite.sh
@@ -18,8 +18,8 @@
 # This is a workaround for https://github.com/LINBIT/linstor-server/issues/331, https://github.com/LINBIT/linstor-server/issues/219
 
 # Check if there are symptoms of lost connection in linstor controller logs
-if test -f "/var/log/linstor-controller/linstor-Satellite.log"; then
-  if [ $(tail -n 1000 /var/log/linstor-controller/linstor-Satellite.log | grep 'Target decrypted buffer is too small' | wc -l) -ne 0 ]; then
+if test -f "/var/log/linstor-satellite/linstor-Satellite.log"; then
+  if [ $(tail -n 1000 /var/log/linstor-satellite/linstor-Satellite.log | grep 'Target decrypted buffer is too small' | wc -l) -ne 0 ]; then
     exit 1
   fi
 fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR addresses an issue where an incorrect file path due to a typographical error in the liveness-satellite.sh script caused the liveness probe to always report success, regardless of the actual state of the service. By correcting the log file path, we ensure the liveness probe functions correctly and reflects the true status of the system.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The typo caused the liveness probe to fail to access the intended log file, misleadingly indicating that the service was always up and running. This fix restores the functionality of the liveness probe, which is crucial for detecting and handling service failures promptly.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Accurate liveness probe responses based on the actual operational status of the linstor-satellite.
- Improved system reliability and automated recovery actions in case of service downtimes.
- Enhanced monitoring accuracy, ensuring system health is correctly reported.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
