### PR TITLE
Fix linstor satellite VPA

### DIFF
--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -13,6 +13,11 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "linstor_resources_cleaner" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -40,6 +45,12 @@ spec:
     - containerName: drbd-prometheus-exporter
       minAllowed:
         {{- include "drbd_prometheus_exporter_resources" . | nindent 8 }}
+      maxAllowed:
+        cpu: 20m
+        memory: 50Mi
+    - containerName: linstor-resources-cleaner
+      minAllowed:
+        {{- include "linstor_resources_cleaner" . | nindent 8 }}
       maxAllowed:
         cpu: 20m
         memory: 50Mi
@@ -97,7 +108,7 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+            {{- include "linstor_resources_cleaner" . | nindent 12 }}
 {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -128,7 +139,7 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+            {{- include "linstor_satellite_resources" . | nindent 12 }}
 {{- end }}
         securityContext:
           privileged: true
@@ -214,7 +225,7 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+            {{- include "drbd_prometheus_exporter_resources" . | nindent 12 }}
 {{- end }}
         securityContext: {}
         terminationMessagePath: /dev/termination-log

--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -56,7 +56,9 @@ spec:
 
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
-        sed -i 's/^drbd$//' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          sed -i 's/^drbd$//' /etc/modules
+        fi
         rmmod drbd_transport_rdma || true
         rmmod drbd_transport_tcp || true
         rmmod drbd || true
@@ -105,8 +107,10 @@ spec:
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
       else
-        if grep -q -E '^drbd$' /etc/modules; then
-          sed -i '/^drbd$/d' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          if grep -q -E '^drbd$' /etc/modules; then
+            sed -i '/^drbd$/d' /etc/modules
+          fi
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
 
@@ -163,8 +167,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    if grep -q -E '^drbd$' /etc/modules; then
-      sed -i '/^drbd$/d' /etc/modules
+    if [ -e "/etc/modules" ]; then
+      if grep -q -E '^drbd$' /etc/modules; then
+        sed -i '/^drbd$/d' /etc/modules
+      fi
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod

--- a/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -56,7 +56,9 @@ spec:
 
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
-        sed -i 's/^drbd$//' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          sed -i 's/^drbd$//' /etc/modules
+        fi
         rmmod drbd_transport_rdma || true
         rmmod drbd_transport_tcp || true
         rmmod drbd || true
@@ -110,8 +112,10 @@ spec:
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
       else
-        if grep -q -E '^drbd$' /etc/modules; then
-          sed -i '/^drbd$/d' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          if grep -q -E '^drbd$' /etc/modules; then
+            sed -i '/^drbd$/d' /etc/modules
+          fi
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
 
@@ -168,8 +172,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/${kernel_version_in_use}/kernel/drivers/
-    if grep -q -E '^drbd$' /etc/modules; then
-      sed -i '/^drbd$/d' /etc/modules
+    if [ -e "/etc/modules" ]; then
+      if grep -q -E '^drbd$' /etc/modules; then
+        sed -i '/^drbd$/d' /etc/modules
+      fi
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -56,7 +56,9 @@ spec:
 
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
-        sed -i 's/^drbd$//' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          sed -i 's/^drbd$//' /etc/modules
+        fi
         rmmod drbd_transport_rdma || true
         rmmod drbd_transport_tcp || true
         rmmod drbd || true
@@ -107,8 +109,10 @@ spec:
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
       else
-        if grep -q -E '^drbd$' /etc/modules; then
-          sed -i '/^drbd$/d' /etc/modules
+        if [ -e "/etc/modules" ]; then
+          if grep -q -E '^drbd$' /etc/modules; then
+            sed -i '/^drbd$/d' /etc/modules
+          fi
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
 
@@ -165,8 +169,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    if grep -q -E '^drbd$' /etc/modules; then
-      sed -i '/^drbd$/d' /etc/modules
+    if [ -e "/etc/modules" ]; then
+      if grep -q -E '^drbd$' /etc/modules; then
+        sed -i '/^drbd$/d' /etc/modules
+      fi
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We have incorrect VPA for some of satellite containers, and have no VPA for linstor-resources-cleaner

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We have satellite daemonset rollout because of incorrect VPA for satellite

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct VPA for node satellite

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
