### PR TITLE
Fix linstor satellite VPA

### DIFF
--- a/templates/linstor-csi/controller.yaml
+++ b/templates/linstor-csi/controller.yaml
@@ -19,12 +19,12 @@ memory: 50Mi
 {{- end }}
 
 {{- define "csi_snapshotter_resources" }}
-cpu: 10m
+cpu: 50m
 memory: 25Mi
 {{- end }}
 
 {{- define "csi_livenessprobe_resources" }}
-cpu: 10m
+cpu: 50m
 memory: 25Mi
 {{- end }}
 
@@ -79,13 +79,13 @@ spec:
       minAllowed:
         {{- include "csi_snapshotter_resources" . | nindent 8 }}
       maxAllowed:
-        cpu: 20m
+        cpu: 100m
         memory: 50Mi
     - containerName: csi-livenessprobe
       minAllowed:
         {{- include "csi_livenessprobe_resources" . | nindent 8 }}
       maxAllowed:
-        cpu: 20m
+        cpu: 100m
         memory: 50Mi
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -113,13 +113,13 @@ spec:
       minAllowed:
         {{- include "csi_livenessprobe_resources" . | nindent 8 }}
       maxAllowed:
-        cpu: 20m
+        cpu: 50m
         memory: 50Mi
     - containerName: csi-node-driver-registrar
       minAllowed:
         {{- include "csi_node_driver_registrar_resources" . | nindent 8 }}
       maxAllowed:
-        cpu: 20m
+        cpu: 50m
         memory: 50Mi
 {{- end }}
 ---

--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -13,6 +13,11 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "linstor_resources_cleaner" }}
+cpu: 10m
+memory: 150Mi
+{{- end }}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -43,6 +48,12 @@ spec:
       maxAllowed:
         cpu: 20m
         memory: 50Mi
+    - containerName: linstor-resources-cleaner
+      minAllowed:
+        {{- include "linstor_resources_cleaner" . | nindent 8 }}
+      maxAllowed:
+        cpu: 10m
+        memory: 150Mi
 {{- end }}
 ---
 apiVersion: apps/v1
@@ -97,7 +108,7 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+            {{- include "linstor_resources_cleaner" . | nindent 12 }}
 {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -136,7 +147,7 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+            {{- include "linstor_satellite_resources" . | nindent 12 }}
 {{- end }}
         securityContext:
           privileged: true
@@ -222,7 +233,7 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+            {{- include "drbd_prometheus_exporter_resources" . | nindent 12 }}
 {{- end }}
         securityContext: {}
         terminationMessagePath: /dev/termination-log

--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -46,13 +46,13 @@ spec:
       minAllowed:
         {{- include "drbd_prometheus_exporter_resources" . | nindent 8 }}
       maxAllowed:
-        cpu: 20m
+        cpu: 100m
         memory: 50Mi
     - containerName: linstor-resources-cleaner
       minAllowed:
         {{- include "linstor_resources_cleaner" . | nindent 8 }}
       maxAllowed:
-        cpu: 10m
+        cpu: 100m
         memory: 150Mi
 {{- end }}
 ---

--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -4,17 +4,17 @@ memory: 250Mi
 {{- end }}
 
 {{- define "drbd_prometheus_exporter_resources" }}
-cpu: 10m
+cpu: 50m
 memory: 25Mi
 {{- end }}
 
 {{- define "drbd_wait_resources" }}
-cpu: 10m
+cpu: 50m
 memory: 25Mi
 {{- end }}
 
 {{- define "linstor_resources_cleaner" }}
-cpu: 10m
+cpu: 50m
 memory: 150Mi
 {{- end }}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We have incorrect VPA for some of satellite containers, and have no VPA for linstor-resources-cleaner

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We have satellite daemonset rollout because of incorrect VPA for satellite

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct VPA for node satellite

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
