### PR TITLE
[controller] Add a check for a Linstor node's AutoplaceTarget property

### DIFF
--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher_test.go
@@ -8,6 +8,65 @@ import (
 )
 
 func TestLinstorResourcesWatcher(t *testing.T) {
+	t.Run("filterNodesByAutoplaceTarget_return_correct_nodes", func(t *testing.T) {
+		nodes := []lapi.Node{
+			{
+				Name: "correct1",
+				Props: map[string]string{
+					autoplaceTarget: "true",
+				},
+			},
+			{
+				Name: "bad",
+				Props: map[string]string{
+					autoplaceTarget: "false",
+				},
+			},
+			{
+				Name:  "correct2",
+				Props: map[string]string{},
+			},
+		}
+
+		expected := []lapi.Node{
+			{
+				Name: "correct1",
+				Props: map[string]string{
+					autoplaceTarget: "true",
+				},
+			},
+			{
+				Name:  "correct2",
+				Props: map[string]string{},
+			},
+		}
+
+		actual := filterNodesByAutoplaceTarget(nodes)
+
+		assert.ElementsMatch(t, expected, actual)
+	})
+
+	t.Run("filterNodesByAutoplaceTarget_return_nothing", func(t *testing.T) {
+		nodes := []lapi.Node{
+			{
+				Name: "bad1",
+				Props: map[string]string{
+					autoplaceTarget: "false",
+				},
+			},
+			{
+				Name: "bad2",
+				Props: map[string]string{
+					autoplaceTarget: "false",
+				},
+			},
+		}
+
+		actual := filterNodesByAutoplaceTarget(nodes)
+
+		assert.Equal(t, 0, len(actual))
+	})
+
 	t.Run("filterNodesByReplicasOnDifferent_returns_correct_nodes", func(t *testing.T) {
 		key := "Aux/kubernetes.io/hostname"
 		values := []string{"test-host1"}


### PR DESCRIPTION
## Description
Add a logic to consider the Linstor's node AutoplaceTarget property for selecting Tie-breaker node.

## Why do we need it, and what problem does it solve?
If node is evacuating, the controller won't select it as a Tie-breaker node. 

## What is the expected result?
The controller will not select the nodes with a property 'AutoplaceTarget' with 'false' value.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
