### PR TITLE
[monitoring] change interval_sx3 and interval_sx4 to rate_interval in grafana dashboard

### DIFF
--- a/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -701,7 +701,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (module) (round(increase(linstor_error_reports_count{module!=\"\", node=~\"$node\"}[$__interval_sx4])))",
+          "expr": "sum by (module) (round(increase(linstor_error_reports_count{module!=\"\", node=~\"$node\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "{{ module }}",
           "refId": "A"
@@ -842,7 +842,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg_over_time(linstor_scrape_duration_seconds[$__interval_sx3])",
+          "expr": "avg_over_time(linstor_scrape_duration_seconds[$__rate_interval])",
           "legendFormat": "allocated",
           "refId": "A"
         }
@@ -1253,7 +1253,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(drbd_device_written_bytes_total[$__interval_sx3]) and topk(5, avg_over_time(drbd_device_written_bytes_total[$__interval_sx3]) > 0)",
+          "expr": "rate(drbd_device_written_bytes_total[$__rate_interval]) and topk(5, avg_over_time(drbd_device_written_bytes_total[$__rate_interval]) > 0)",
           "instant": false,
           "legendFormat": "{{name}} on {{node}}",
           "refId": "A"
@@ -1342,7 +1342,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(drbd_device_read_bytes_total[$__interval_sx3]) and topk(5, avg_over_time(drbd_device_read_bytes_total[$__interval_sx3]) > 0)",
+          "expr": "rate(drbd_device_read_bytes_total[$__rate_interval]) and topk(5, avg_over_time(drbd_device_read_bytes_total[$__rate_interval]) > 0)",
           "instant": false,
           "legendFormat": "{{name}} on {{node}}",
           "refId": "A"
@@ -1453,7 +1453,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "avg_over_time(scrape_duration_seconds{job=\"linstor-node\"}[$__interval_sx3])",
+          "expr": "avg_over_time(scrape_duration_seconds{job=\"linstor-node\"}[$__rate_interval])",
           "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change interval_sx3 and interval_sx4 to rate_interval in grafana dashboard

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We use obsolete directives interval_sx3 and interval_sx4 in dashboard. It isn't compatible with Grafana 10, so we change in to rate_interval

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Proper directives in grafana dashboard

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
