### PR TITLE
[linstor] Fix KubeSchedulerConfiguration API version

### DIFF
--- a/templates/linstor-scheduler/configmap.yaml
+++ b/templates/linstor-scheduler/configmap.yaml
@@ -6,12 +6,11 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-scheduler")) | nindent 2 }}
 data:
-  {{- if semverCompare ">= 1.22" .Values.global.discovery.kubernetesVersion }}
   scheduler-config.yaml: |-
-    {{- if semverCompare ">= 1.23" .Values.global.discovery.kubernetesVersion }}
-    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    {{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
+    apiVersion: kubescheduler.config.k8s.io/v1
     {{- else }}
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
     {{- end }}
     kind: KubeSchedulerConfiguration
     profiles:
@@ -24,21 +23,3 @@ data:
         enableHTTPS: false
         httpTimeout: 300000s
         nodeCacheCapable: false
-  {{- else }}
-  policy.cfg: |-
-    {
-      "kind": "Policy",
-      "apiVersion": "v1",
-      "extenders": [
-        {
-          "urlPrefix": "http://localhost:8099",
-          "apiVersion": "v1beta1",
-          "filterVerb": "filter",
-          "prioritizeVerb": "prioritize",
-          "weight": 5,
-          "enableHttps": false,
-          "nodeCacheCapable": false
-        }
-      ]
-    }
-  {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix KubeSchedulerConfiguration API version

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

kubescheduler.config.k8s.io/v1beta3 is removed in k8s 1.29, so kubescheduler can't be launched

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Working kubescheduler on k8s 1.29

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
