### PR TITLE
[linstor] Allow storage-pool delete command in wrapper

### DIFF
--- a/images/linstor-server/client-wrapper.sh
+++ b/images/linstor-server/client-wrapper.sh
@@ -24,7 +24,7 @@ allowed=false
 
 if [[ -z "$1" || "--help" == "$1" || "-h" == "$1" ]]; then
   echo "This wrapper is designed to minimize manual intervention in the module's operation. We are continuously improving the built-in capabilities to avoid the need for console commands. Please try to use them as much as possible. The allowed commands at the moment are:"
-  echo "- storage-pool list/show"
+  echo "- storage-pool list/show/delete"
   echo "- node list/show"
   echo "- resource list/show/lv"
   echo "- volume list/show"
@@ -54,6 +54,11 @@ done
 
 # Allow linstor resource-definition delete
 if [[ "$1" == "resource-definition" ]] && [[ "$2" == "delete" ]]; then
+  allowed=true
+fi
+
+# Allow linstor storage pool delete
+if [[ "$1" == "storage-pool" ]] && [[ "$2" == "delete" ]]; then
   allowed=true
 fi
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Allow storage-pool delete command in wrapper

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Now it's not possible to delete unused storage pool

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Possibility of storage pool deletion

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
