### PR TITLE
[monitoring] Add D8DrbdPeerDeviceIsOutOfSync alert description

### DIFF
--- a/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/monitoring/prometheus-rules/drbd-devices.yaml
@@ -66,7 +66,44 @@
         description: |
           DRBD device {{ $labels.name }} on node {{ $labels.node }} has out-of-sync data with {{ $labels.conn_name }}
 
-          Please, contact tech support for assistance.
+          The recommended course of action:
+          1. Login into node with the problem:
+
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
+             ```
+
+          2. Check the LINSTOR peer node state:
+
+             ```
+             linstor node list -n {{ $labels.conn_name }}
+             ```
+
+          3. Check the LINSTOR resource states:
+
+             ```
+             linstor resource list -r {{ $labels.name }}
+             ```
+
+          4. View the status of the DRBD device on the node and try to figure out why it has out-of-sync data with {{ $labels.conn_name }}:
+
+             ```
+             drbdsetup status {{ $labels.name }} --statistics
+             dmesg --color=always | grep 'drbd {{ $labels.name }}'
+             ```
+
+          5. Consider reconnect resource with the peer node:
+
+             ```
+             drbdadm disconnect {{ $labels.name }}:{{ $labels.conn_name }}
+             drbdadm connect {{ $labels.name }}:{{ $labels.conn_name }}
+             ```
+
+          6. Check if problem has solved, device should have no out-of-sync data:
+
+             ```
+             drbdsetup status {{ $labels.name }} --statistics
+             ```
 
     - alert: D8DrbdDeviceIsNotConnected
       expr: max by (node, conn_name, name) (drbd_connection_state{drbd_connection_state!="UpToDate", drbd_connection_state!="Connected"} == 1)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added D8DrbdPeerDeviceIsOutOfSync alert description

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

There is possible problems with DRBD volumes, that can be solved manually

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Course of action in case of DRBD volumes out of sync

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
