### PR TITLE
[controller] Change LVMVolumeGroup size field type from string to quantity

### DIFF
--- a/images/sds-replicated-volume-controller/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-replicated-volume-controller/api/v1alpha1/lvm_volume_group.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 type LvmVolumeGroupList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -34,8 +37,8 @@ type LvmVolumeGroup struct {
 }
 
 type SpecThinPool struct {
-	Name string `json:"name"`
-	Size string `json:"size"`
+	Name string            `json:"name"`
+	Size resource.Quantity `json:"size"`
 }
 
 type LvmVolumeGroupSpec struct {
@@ -46,11 +49,11 @@ type LvmVolumeGroupSpec struct {
 }
 
 type LvmVolumeGroupDevice struct {
-	BlockDevice string `json:"blockDevice"`
-	DevSize     string `json:"devSize"`
-	PVSize      string `json:"pvSize"`
-	PVUuid      string `json:"pvUUID"`
-	Path        string `json:"path"`
+	BlockDevice string            `json:"blockDevice"`
+	DevSize     resource.Quantity `json:"devSize"`
+	PVSize      resource.Quantity `json:"pvSize"`
+	PVUuid      string            `json:"pvUUID"`
+	Path        string            `json:"path"`
 }
 
 type LvmVolumeGroupNode struct {
@@ -59,17 +62,17 @@ type LvmVolumeGroupNode struct {
 }
 
 type StatusThinPool struct {
-	Name       string `json:"name"`
-	ActualSize string `json:"actualSize"`
-	UsedSize   string `json:"usedSize"`
+	Name       string            `json:"name"`
+	ActualSize resource.Quantity `json:"actualSize"`
+	UsedSize   resource.Quantity `json:"usedSize"`
 }
 
 type LvmVolumeGroupStatus struct {
-	AllocatedSize string               `json:"allocatedSize"`
+	AllocatedSize resource.Quantity    `json:"allocatedSize"`
 	Health        string               `json:"health"`
 	Message       string               `json:"message"`
 	Nodes         []LvmVolumeGroupNode `json:"nodes"`
 	ThinPools     []StatusThinPool     `json:"thinPools"`
-	VGSize        string               `json:"vgSize"`
+	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
 }

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_watcher.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_watcher.go
@@ -23,6 +23,7 @@ const (
 	NonOperationalByStoragePool           = "storage.deckhouse.io/nonOperational-invalid-storage-pool-selected"
 	NonOperationalByZonesLabel            = "storage.deckhouse.io/nonOperational-invalid-zones-selected"
 	NonOperationalByReplicasLabel         = "storage.deckhouse.io/nonOperational-not-enough-nodes-in-zones"
+	NonOperationalLabel                   = "storage.deckhouse.io/nonOperational"
 )
 
 func RunReplicatedStorageClassWatcher(
@@ -199,7 +200,7 @@ func ReconcileReplicatedStorageClassReplication(
 			err := errors.New("unsupported replication type")
 			log.Error(err, fmt.Sprintf("[ReconcileReplicatedStorageClassReplication] replication type validation failed for ReplicatedStorageClass %s", rsc.Name))
 
-			setNonOperationalLabelOnStorageClass(ctx, cl, log, rsc, "storage.deckhouse.io/nonOperational")
+			setNonOperationalLabelOnStorageClass(ctx, cl, log, rsc, NonOperationalLabel)
 		}
 	}
 	log.Info("[ReconcileReplicatedStorageClassReplication] ends reconcile")


### PR DESCRIPTION
## Description
Refactoring due to size field type changes from string to quantity.

## Why do we need it, and what problem does it solve?
Less parsing and more accurate code.

## What is the expected result?
No type string for any size field of any resource.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
