### PR TITLE
[linstor] Allow resorce-definition list-properties

### DIFF
--- a/images/linstor-server/client-wrapper.sh
+++ b/images/linstor-server/client-wrapper.sh
@@ -28,7 +28,7 @@ if [[ -z "$1" || "--help" == "$1" || "-h" == "$1" ]]; then
   echo "- node list/show"
   echo "- resource list/show/lv"
   echo "- volume list/show"
-  echo "- resource-definition list/show"
+  echo "- resource-definition list/show/delete/list-properties"
   echo "- error-reports list/show"
   echo "- controller version"
   echo "- advise resource/maintainance"
@@ -69,6 +69,10 @@ if [[ $(echo "${valid_subcommands_list[@]}" | fgrep -w -- $1) ]]; then
   fi
 
   if [[ "$2" == "s" || "$2" == "show" ]]; then
+    allowed=true
+  fi
+
+  if [[ "$2" == "lp" || "$2" == "list-properties" ]]; then
     allowed=true
   fi
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Allow resorce-definition list-properties command in wrapper

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In some cases, the user must see properties for the resource definition.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Allowed resource-definition list-properties command

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
