### PR TITLE
[linstor] Allow dangerous commands in wrapper

### DIFF
--- a/images/linstor-server/client-wrapper.sh
+++ b/images/linstor-server/client-wrapper.sh
@@ -19,6 +19,7 @@ valid_subcommands_list=("storage-pool" "sp" "node" "n" "resource" "r" "volume" "
 valid_subcommands_ver=("controller" "c")
 valid_subcommands_lv=("resource" "r")
 valid_subcommands_advise=("advise" "adv")
+valid_subcommands_create_delete=("storage-pool" "node" "resource" "volume" "resource-definition")
 valid_keys=("-m" "--output-version=v1")
 allowed=false
 
@@ -33,13 +34,19 @@ if [[ -z "$1" || "--help" == "$1" || "-h" == "$1" ]]; then
   echo "- controller version"
   echo "- advise resource/maintainance"
   echo "- resource-definition delete"
+  echo "- --yes-i-am-sane-and-i-understand-what-i-am-doing storage-pool/node/resource/volume/resource-definition create/delete (!key before command is required!)"
   exit 0
 fi
 
 originalKeys=("$@")
 checkKeys=true
+allowDangerousCommands=false
 
 while [[ $checkKeys == true ]]; do
+  if [[ "$1" == "--yes-i-am-sane-and-i-understand-what-i-am-doing" ]]; then
+    allowDangerousCommands=true
+    shift
+  fi
   if [[ $(echo "${valid_keys[@]}" | fgrep -w -- $1) ]]; then
     shift
   else
@@ -52,14 +59,11 @@ done
    allowed=true
  fi
 
-# Allow linstor resource-definition delete
-if [[ "$1" == "resource-definition" ]] && [[ "$2" == "delete" ]]; then
-  allowed=true
-fi
-
-# Allow linstor storage pool delete
-if [[ "$1" == "storage-pool" ]] && [[ "$2" == "delete" ]]; then
-  allowed=true
+# Allow dangerous commands (delete/create)
+if [[ $(echo "${valid_subcommands_create_delete[@]}" | fgrep -w -- $1) ]] && [[ $allowDangerousCommands == true ]]; then
+  if [[ "$2" == "create" || "$2" == "delete" ]]; then
+    allowed=true
+  fi
 fi
 
 # check for allowed linstor ... l and linstor ... list commands


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Allow create/delete commands for resource/storage-pool/resource-definition/node

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In situations with broken nodes/resources we need possibility to create/delete some resources

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Ability to repair broken resources

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
