### PR TITLE
[linstor] Add script replicas_manager.sh

### DIFF
--- a/images/sds-replicated-volume-controller/tools/replicas_manager.sh
+++ b/images/sds-replicated-volume-controller/tools/replicas_manager.sh
@@ -1,0 +1,834 @@
+#!/bin/bash
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export TIMEOUT_SEC=10
+export DISKLESS_STORAGE_POOL="DfltDisklessStorPool"
+export LINSTOR_NAMESPACE="d8-sds-replicated-volume"
+export DATE_TIME=$(date +"%Y-%m-%d_%H-%M-%S")
+export LOG_FILE="linstor_replicas_manager_${DATE_TIME}.log"
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required but it's not installed.  Aborting." >&2; exit 1; }
+touch ${LOG_FILE}
+exec > >(tee -a ${LOG_FILE}) 2>&1
+
+execute_command() {
+  modified_command=$(echo "$@" | sed 's/originallinstor/linstor/g')
+  echo "Executing command: $modified_command"
+  if [[ "${NON_INTERACTIVE}" == "true" ]]; then
+    count=0
+    max_attempts=10
+    until eval "$@"; do
+      echo "Command \"$@\" failed. Retrying in $TIMEOUT_SEC seconds."
+      sleep $TIMEOUT_SEC
+      ((count++))
+      if [[ $count -eq $max_attempts ]]; then
+        echo "Maximum number of attempts reached. Command \"$@\" failed."
+        exit_function
+      fi
+    done
+    return
+  fi
+
+  while true; do
+    eval "$@"
+    local exit_code=$?
+    if [[ $exit_code -eq 0 ]]; then
+        break
+    else
+      echo "Command \"$@\" failed with exit code \"${exit_code}\""
+      if get_user_confirmation "Would you like to retry?" "y" "n"; then
+        sleep 2
+        continue
+      else
+        if get_user_confirmation "Ignore the error and continue?" "y" "n"; then  
+          break
+        else
+          exit_function
+        fi
+      fi
+    fi
+  done
+}
+
+linstor_check_controller_online() {
+  echo "Checking for LINSTOR controller online"
+  while true; do
+    local count=0
+    local max_attempts=20
+    until linstor node list > /dev/null 2>&1 || [ $count -eq $max_attempts ]; do
+      echo "LINSTOR controller is not online. Waiting $TIMEOUT_SEC seconds and rechecking for LINSTOR controller online. Attempt $((count+1))/$max_attempts."
+      sleep $TIMEOUT_SEC
+      ((count++))
+    done
+
+    if [ $count -eq $max_attempts ]; then
+      echo "Timeout reached. LINSTOR controller is not online."
+      if get_user_confirmation "Exit the script? If not, the script will continue to wait for the LINSTOR controller to come online." "y" "n"; then
+        exit_function
+      else
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking for LINSTOR controller online"
+        sleep $TIMEOUT_SEC
+        continue
+      fi
+    fi
+    echo "LINSTOR controller is online"
+    return
+  done
+}
+
+exec_linstor_with_exit_code_check() {
+  execute_command kubectl -n ${LINSTOR_NAMESPACE} exec -ti deploy/linstor-controller -c linstor-controller -- originallinstor "$@"
+}
+
+linstor() {
+  kubectl -n ${LINSTOR_NAMESPACE} exec -ti deploy/linstor-controller -c linstor-controller -- originallinstor "$@"
+}
+
+linstor_check_faulty() {
+  linstor_check_controller_online
+
+  while true; do
+    local count=0
+    local max_attempts=5
+
+    until [ $count -eq $max_attempts ]; do
+      echo "Checking for faulty resources"
+      if [[ -n $EXCLUDED_RESOURCES_FROM_CHECK ]]; then
+        faulty_resource_count=$(linstor resource list --faulty | tee /dev/tty | grep -v -i sync | grep -v -E "$EXCLUDED_RESOURCES_FROM_CHECK" | grep  "[a-zA-Z0-9]" | wc -l)
+      else
+        faulty_resource_count=$(linstor resource list --faulty | tee /dev/tty | grep -v -i sync | grep  "[a-zA-Z0-9]" | wc -l)
+      fi
+      if (( $faulty_resource_count > 1)); then
+        echo "Faulty resources found."
+        if get_user_confirmation "Perform recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+          echo "Waiting $TIMEOUT_SEC seconds and rechecking for faulty resources"
+          sleep $TIMEOUT_SEC
+          ((count++))
+        else
+          exit_function
+        fi
+      else
+        echo "No faulty resources found"
+        linstor_check_corrupt_resources
+        return
+      fi
+    done
+
+    if [ $count -eq $max_attempts ]; then
+      echo "Maximum number of attempts reached. Faulty resources are still present."
+      if get_user_confirmation "Exit the script? If not, the script will continue to wait and recheck for faulty resources." "y" "n"; then
+        exit_function
+      else
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking for faulty resources"
+        sleep $TIMEOUT_SEC
+        continue
+      fi
+    fi
+  done
+}
+
+linstor_check_corrupt_resources() {
+  echo "Checking for corrupted resources"
+  count=0
+  max_attempts=5
+
+  until [ $count -eq $max_attempts ]; do
+    ((count++))
+    if [[ -n $EXCLUDED_RESOURCES_FROM_CHECK ]]; then
+      exec_linstor_with_exit_code_check resource list-volumes | grep -v -E "$EXCLUDED_RESOURCES_FROM_CHECK" | grep -E -- "-1 KiB|None"
+    else
+      exec_linstor_with_exit_code_check resource list-volumes | grep -E -- "-1 KiB|None"
+    fi
+    if [ $? -eq 0 ]; then
+      echo "Corrupted resources found."
+      if get_user_confirmation "Perform recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking for corrupted resources"
+        sleep $TIMEOUT_SEC
+      else
+        exit_function
+      fi
+    else
+      echo "No corrupted resources found"
+      return
+    fi
+  done
+
+  if [ $count -eq $max_attempts ]; then
+    echo "Maximum number of attempts reached. Corrupted resources are still present."
+    exit_function
+  fi
+}
+
+get_user_confirmation() {
+  local prompt="$1"
+  local positive_case="$2"
+  local negative_case="$3"
+
+  if [[ "${NON_INTERACTIVE}" == "true" ]]; then
+    return 0
+  fi
+
+  while true; do
+    echo -n "$prompt ($positive_case/$negative_case): "
+    read user_input
+    
+    case "$user_input" in
+      "$positive_case")
+        return 0  # true
+        ;;
+      "$negative_case")
+        return 1  # false
+        ;;
+      *)
+        echo "Invalid input. Try again."
+        sleep 1
+        ;;
+    esac
+  done
+
+}
+
+exit_function(){
+  if [[ "${NON_INTERACTIVE}" == "true" ]]; then
+    echo "Terminating the script"
+    exit 1
+  fi
+
+  if get_user_confirmation "Terminate the script?" "y" "n"; then
+    echo "Terminating the script"
+    exit 0
+  fi
+  echo "The script operation will be continued."
+}
+
+linstor_check_advise() {
+  while true; do
+    echo "Checking for advise"
+    if (( $(linstor advise r | tee /dev/tty | grep  "[a-zA-Z0-9]" | wc -l) > 1)); then
+      echo "Advise found."
+      echo "It is recommended to perform the advised actions manually."
+      if get_user_confirmation "Exit the script? If not, the script will continue and recheck for advise." "y" "n"; then
+        exit_function
+      else
+        linstor_check_faulty
+        continue
+      fi
+    else
+      echo "No advise found"
+      return
+    fi
+  done
+}
+
+linstor_check_connection() {
+  while true; do
+    count=0
+    max_attempts=5
+
+
+    until [ $count -eq $max_attempts ]; do
+      echo "Checking connection of LINSTOR controller to its satellites."
+      ((count++))
+
+      SATELLITES_ONLINE=$(linstor -m --output-version=v1 node list | jq -r '.[][] | select(.type == "SATELLITE" and .connection_status == "ONLINE").name')
+      if [[ -z $SATELLITES_ONLINE ]]; then
+        echo "No satellites are online. This is usually a sign of issues with the LINSTOR controller operation. It is recommended to restart the controller and satellites."
+        echo "List of satellites:"
+        exec_linstor_with_exit_code_check node list
+        if get_user_confirmation "Perform connection recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+          echo "Waiting $TIMEOUT_SEC seconds and rechecking the connection of LINSTOR controller to its satellites"
+          sleep $TIMEOUT_SEC
+          continue
+        else
+          exit_function
+        fi
+      else
+        if [ $(linstor -m --output-version=v1 storage-pool list -s ${DISKLESS_STORAGE_POOL} -n $SATELLITES_ONLINE | jq '.[][].reports[]?.message' | grep 'No active connection to satellite' | wc -l) -ne 0 ]; then
+          echo "Some satellites are not connected, even though they are online. This is usually a sign of issues with the LINSTOR controller operation. It is recommended to restart the controller and satellites."
+          echo "List of satellites:"
+          exec_linstor_with_exit_code_check node list
+          echo "List of storage pools:"
+          exec_linstor_with_exit_code_check storage-pool list
+          if get_user_confirmation "Perform connection recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+            echo "Waiting $TIMEOUT_SEC seconds and rechecking the connection of LINSTOR controller to its satellites"
+            sleep $TIMEOUT_SEC
+            continue
+          else
+            exit_function
+          fi
+        else
+          echo "LINSTOR controller has connection with all satellites that are online."
+          return
+        fi
+      fi
+    done
+
+    if [ $count -eq $max_attempts ]; then
+      echo "Maximum number of attempts reached. LINSTOR controller has no connection with its satellites."
+      if get_user_confirmation "Exit the script? If not, the script will continue and recheck for connection." "y" "n"; then
+        exit_function
+      else
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking the connection of LINSTOR controller to its satellites"
+        sleep $TIMEOUT_SEC
+        continue
+      fi
+    fi
+  done
+}
+
+linstor_wait_sync() {
+  local max_number_of_parallel_syncs=$1
+  while true; do
+    count=0
+    max_attempts=180
+    until [ $count -eq $max_attempts ]; do
+      echo "Checking the number of replicas currently syncing"
+      ((count++))
+      export SYNC_TARGET_RESOURCES=$(linstor -m --output-version=v1 resource list-volumes | jq -r '.[][] | select(.volumes[] | (.state.disk_state // empty) | contains("SyncTarget")).name') 
+      if [[ -n "${SYNC_TARGET_RESOURCES}" ]]; then
+        echo "Resources found to be syncing at the moment. List of such resources:"
+        exec_linstor_with_exit_code_check resource list-volumes -r ${SYNC_TARGET_RESOURCES}
+        local number_of_parallel_syncs=$(echo ${SYNC_TARGET_RESOURCES} | wc -w)
+        if (( ${number_of_parallel_syncs} > ${max_number_of_parallel_syncs} )); then
+          echo "Number of sync operations at the moment=${number_of_parallel_syncs}. This is more than the maximum allowed number of simultaneously performed sync operations (${max_number_of_parallel_syncs}). Waiting for synchronization to complete."
+          sleep ${TIMEOUT_SEC}
+          continue
+        else
+          echo "Number of sync operations at the moment=${number_of_parallel_syncs}. This is less than or equal to the maximum allowed number of simultaneously performed sync operations (${max_number_of_parallel_syncs}). Ending synchronization wait."
+          return
+        fi
+      else
+        echo "No resources found to be syncing at the moment. Ending synchronization wait."
+        return
+      fi
+    done
+
+    if [ $count -eq $max_attempts ]; then
+      echo "Maximum number of attempts reached. Resources are still syncing."
+      if get_user_confirmation "Exit the script? If not, the script will continue and recheck for synchronization." "y" "n"; then
+        exit_function
+      else
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking the number of replicas currently syncing"
+        sleep $TIMEOUT_SEC
+        continue
+      fi
+    fi
+  done
+}
+
+
+is_linstor_satellite_online() {
+
+  while true; do
+    count=0
+    max_attempts=10
+    until [ $count -eq $max_attempts ]; do
+      echo "Checking the connection status of node ${NODE_FOR_EVICT} in LINSTOR"
+      ((count++))
+      node_connection_status=$(linstor -m --output-version=v1 node list -n ${NODE_FOR_EVICT} | jq -r --arg nodeName "${NODE_FOR_EVICT}" '.[][] | select(.name == $nodeName).connection_status')
+      if [[ ${node_connection_status^^} == "ONLINE" ]]; then
+        return 0
+      else
+        echo "Node ${NODE_FOR_EVICT} is not ONLINE in LINSTOR."
+        echo "List of satellites:"
+        exec_linstor_with_exit_code_check node list 
+        if get_user_confirmation "Perform recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+          echo "Waiting $TIMEOUT_SEC seconds and rechecking the connection status of node ${NODE_FOR_EVICT} in LINSTOR"
+          sleep $TIMEOUT_SEC
+          continue
+        else
+          return 1
+        fi
+      fi
+    done
+
+    if [ $count -eq $max_attempts ]; then
+      echo "Maximum number of attempts reached. Node ${NODE_FOR_EVICT} is not ONLINE in LINSTOR."
+      echo "List of satellites:"
+      exec_linstor_with_exit_code_check node list
+      if get_user_confirmation "Stop checking? If not, the script will continue and recheck for the connection status of node ${NODE_FOR_EVICT} in LINSTOR." "y" "n"; then
+        return 1
+      else
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking the connection status of node ${NODE_FOR_EVICT} in LINSTOR"
+        sleep $TIMEOUT_SEC
+        continue
+      fi
+    fi
+  done
+}
+
+is_linstor_satellite_does_not_exist() {
+node_info=$(linstor -m --output-version=v1 node list -n ${NODE_FOR_EVICT} | jq -r --arg nodeName "${NODE_FOR_EVICT}" '.[][] | select(.name == $nodeName).connection_status')
+if [[ -z $node_info ]]; then
+  echo "Node ${NODE_FOR_EVICT} does not exist in LINSTOR."
+  echo "List of satellites:"
+  exec_linstor_with_exit_code_check node list
+  return 0
+else
+  return 1
+fi
+}
+
+linstor_change_replicas_count() {
+  local replicas_to_add=$1
+  shift
+  local timeout=$1
+  shift
+  local resource_and_group_names=$1
+  shift
+  local resource_groups=$1
+  shift
+  local resource_names_list=("$@")
+
+  
+  local changed_resources=0
+
+  for resource_name in $resource_names_list; do
+    linstor_wait_sync 3
+    echo "Beginning the process of changing the count of diskfull replicas for resource ${resource_name}"
+
+    local is_tiebreaker_needed=false
+    resource_group=$(echo $resource_and_group_names | jq -r --arg resource_name "${resource_name}" '. | select(.resource == $resource_name).resource_group')
+    place_count=$(echo $resource_groups | jq -r --arg resource_group "${resource_group}" '. | select(.resource_group == $resource_group).place_count')
+
+    desired_diskful_replicas_count=$((place_count + replicas_to_add))
+    # if (( $desired_diskful_replicas_count % 2 == 0 )); then # auto tiebreaker is not worked with more than 2 replicas (4, 6, 8, etc.)
+    if (( $desired_diskful_replicas_count == 2 )); then
+      is_tiebreaker_needed=true
+    fi
+
+    while true; do
+      count=0
+      max_attempts=10
+      until [ $count -eq $max_attempts ]; do
+        RESOURCE_NODES=$(linstor -m --output-version=v1 resource list-volumes  -r "${resource_name}" | jq '[.[][] | {node_name: .node_name, storage_pool: .volumes[0].storage_pool_name, allocated_size_kib: .volumes[0].allocated_size_kib}]')
+        resource_storage_pools=$(echo $RESOURCE_NODES | jq 'group_by(.storage_pool) | map({storage_pool: .[0].storage_pool, count: length})')
+        diskful_storage_pools_count=$(echo $resource_storage_pools | jq --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[] | select(.storage_pool != $disklessStorPoolName)] | length')
+
+        if (( $diskful_storage_pools_count > 1 )); then
+            echo "Error: More than one diskful storage pool found for resource ${resource_name}."
+            echo $RESOURCE_NODES
+            exit 1
+        fi
+
+        diskful_storage_pool_name=$(echo $resource_storage_pools | jq -r --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '.[] | select(.storage_pool != $disklessStorPoolName) | .storage_pool')
+        current_diskful_replicas_count=$(echo $RESOURCE_NODES | jq --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[] | select(.storage_pool != $disklessStorPoolName)] | length')
+
+        # current_diskful_replicas_count=$(linstor -m --output-version=v1 resource list -r ${resource_name} | jq -r  --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[][] | select(.props.StorPoolName != $disklessStorPoolName).name] | length')    
+        ((count++))
+        if [[ -z $RESOURCE_NODES || -z $current_diskful_replicas_count ]]; then
+          echo "Warning! Can't get the resource nodes or the total number of diskfull replicas for resource ${resource_name}."
+          echo "Resource status:"
+          exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+          if get_user_confirmation "Perform recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+            echo "Waiting $TIMEOUT_SEC seconds and rechecking the total number of diskfull replicas for resource ${resource_name}"
+            sleep $TIMEOUT_SEC
+          else
+            exit_function
+          fi
+        else
+          break
+        fi
+      done
+
+      if [ $count -eq $max_attempts ]; then
+        echo "Maximum number of attempts reached. Can't get the total number of diskfull replicas for resource ${resource_name}."
+        echo "Resource status:"
+        exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+        if get_user_confirmation "Exit the script? If not, the script will continue and recheck for the total number of diskfull replicas for resource ${resource_name}." "y" "n"; then
+          exit_function
+        else
+          echo "Waiting $TIMEOUT_SEC seconds and rechecking the total number of diskfull replicas for resource ${resource_name}"
+          sleep $TIMEOUT_SEC
+          continue
+        fi
+      fi
+      break
+    done
+
+    echo "Current status of the resource:"
+    exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+    sleep 2
+    if (( ${current_diskful_replicas_count} < ${desired_diskful_replicas_count} )); then
+      difference=$((desired_diskful_replicas_count - current_diskful_replicas_count))
+      eval "$(get_sorted_free_nodes "$RESOURCE_NODES" "$ALL_STORAGE_POOLS_NODES" "${diskful_storage_pool_name}")"
+
+      echo "The total number of diskfull replicas for resource ${resource_name} (${current_diskful_replicas_count}) less then the desired number of replicas(${desired_diskful_replicas_count}). Adding ${difference} diskfull replicas for this resource"
+      for ((i=0; i<difference; i++)); do
+        if [ $i -ge ${#sorted_free_nodes[@]} ]; then
+          echo "Error: Not enough free nodes"
+          echo "sorted_free_nodes=${sorted_free_nodes[@]}"
+          echo "i=${i}"
+          echo free nodes count=${#sorted_free_nodes[@]}
+          echo RESOURCE_NODES=${RESOURCE_NODES}
+          echo ALL_STORAGE_POOLS_NODES=${ALL_STORAGE_POOLS_NODES}
+          echo diskful_storage_pool_name=${diskful_storage_pool_name}
+          exit_function
+          break
+        fi
+
+        node_available_free_space=$(echo ${sorted_free_nodes[$i]} | cut -d' ' -f1)
+        node_name_for_new_replica=$(echo ${sorted_free_nodes[$i]} | cut -d' ' -f2)
+        resource_allocated_size_kib=$(echo $RESOURCE_NODES | jq '.[].allocated_size_kib' | sort -nr | head -n 1)
+        
+        if (( ${resource_allocated_size_kib} > ${node_available_free_space} )); then
+          echo "Node ${node_name_for_new_replica} has ${node_available_free_space} free space. New replica needs ${resource_allocated_size_kib} space. Error: Not enough free space on node ${node_name_for_new_replica}"
+          exit_function
+          break
+        fi
+
+        echo "Node ${node_name_for_new_replica} has ${node_available_free_space} free space. New replica needs ${resource_allocated_size_kib} space. Creating new replica on this node."
+        echo "Performing checks before create new replica on node \"${node_name_for_new_replica}\""
+        linstor_check_faulty
+
+        echo "Creating new replica on node \"${node_name_for_new_replica}\" for resource \"${resource_name}\""
+        exec_linstor_with_exit_code_check resource create ${node_name_for_new_replica} ${resource_name} --storage-pool ${diskful_storage_pool_name}
+        
+        ALL_STORAGE_POOLS_NODES=$(echo $ALL_STORAGE_POOLS_NODES | jq --arg node_name "${node_name_for_new_replica}" --arg diskfulStoragePoolName "${diskful_storage_pool_name}" --argjson resource_allocated_size_kib "${resource_allocated_size_kib}" '
+          map(if .node_name == $node_name and .storage_pool_name == $diskfulStoragePoolName then .free_capacity -= $resource_allocated_size_kib else . end)
+        ')
+
+        sleep ${timeout}
+        echo "Resource status after create new replica:"
+        exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+        
+      done
+
+      while true; do
+        count=0
+        max_attempts=10
+        until [ $count -eq $max_attempts ]; do
+          current_diskful_replicas_count_new=$(linstor -m --output-version=v1 resource list -r ${resource_name} | jq -r  --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[][] | select(.props.StorPoolName != $disklessStorPoolName).name] | length')
+          ((count++))
+          if [[ -z $current_diskful_replicas_count_new ]]; then
+            echo "Warning! Can't get the total number of diskfull replicas for resource ${resource_name}."
+            echo "Resource status:"
+            exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+            if get_user_confirmation "Perform recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+              echo "Waiting $TIMEOUT_SEC seconds and rechecking the total number of diskfull replicas for resource ${resource_name}"
+              sleep $TIMEOUT_SEC
+            else
+              exit_function
+            fi
+          else
+            break
+          fi
+        done
+
+        if [ $count -eq $max_attempts ]; then
+          echo "Maximum number of attempts reached. Can't get the total number of diskfull replicas for resource ${resource_name}."
+          echo "Resource status:"
+          exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+          if get_user_confirmation "Exit the script? If not, the script will continue and recheck for the total number of diskfull replicas for resource ${resource_name}." "y" "n"; then
+            exit_function
+          else
+            echo "Waiting $TIMEOUT_SEC seconds and rechecking the total number of diskfull replicas for resource ${resource_name}"
+            sleep $TIMEOUT_SEC
+            continue
+          fi
+        fi
+        break
+      done
+      
+      if (( ${current_diskful_replicas_count_new} != ${desired_diskful_replicas_count} )); then
+        echo "Warning! The total number of diskfull replicas for resource ${resource_name} (${current_diskful_replicas_count}) does not equal the desired number of replicas(${desired_diskful_replicas_count}) even after changing the replica count. The following command was executed: \"linstor resource create ${node_name_for_new_replica} ${resource_name} --storage-pool ${diskful_storage_pool_name}\". Manual action required."
+        exit_function
+      fi
+      changed_resources=$((changed_resources + 1))
+    else
+      echo "The total number of diskfull replicas for resource ${resource_name} (${current_diskful_replicas_count}) not less then desired number of diskfull replicas(${desired_diskful_replicas_count}). Skipping creating new diskful replicas for this resource"
+    fi
+    if [[ ${is_tiebreaker_needed} == true ]]; then
+        echo "Resource ${resource_name} has two diskful replicas. Checking for the presence of a TieBreaker for this resource."
+        create_tiebreaker ${resource_name}
+    fi
+          
+    echo "Processing of resource $resource_name completed."
+    sleep 2
+  done
+  return $changed_resources
+}
+
+
+get_sorted_free_nodes() {
+  local resource_nodes=$1
+  local all_storage_pools_nodes=$2
+  local storage_pool_name=$3
+
+  resource_all_nodes=($(echo $resource_nodes | jq -r '.[].node_name'))
+  # resource_diskful_nodes=($(echo $resource_nodes | jq -r --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '.[] | select(.storage_pool != $disklessStorPoolName) | .node_name'))
+  nodes_for_storage_pool=($(echo $all_storage_pools_nodes | jq -r --arg storagePoolName "${storage_pool_name}" '.[] | select(.storage_pool_name == $storagePoolName) | .node_name'))
+  free_capacities=($(echo $all_storage_pools_nodes | jq -r --arg storagePoolName "${storage_pool_name}" '.[] | select(.storage_pool_name == $storagePoolName) | .free_capacity'))
+
+  free_nodes=()
+
+  for i in "${!nodes_for_storage_pool[@]}"; do
+      node=${nodes_for_storage_pool[$i]}
+      if [[ ! " ${resource_all_nodes[@]} " =~ " ${node} " ]]; then
+        if [[ "$node" != "$NODE_FOR_EVICT" ]]; then
+          free_nodes+=("${free_capacities[$i]} ${node}")
+        fi
+      fi
+  done
+
+  IFS=$'\n' sorted_free_nodes=($(sort -nr <<<"${free_nodes[*]}"))
+  unset IFS
+
+  declare -p sorted_free_nodes
+}
+
+create_tiebreaker() {
+  local resource_name=$1
+  local all_storage_pools_nodes=$2
+
+  while true; do
+    count=0
+    max_attempts=10
+    until [ $count -eq $max_attempts ]; do
+      # diskless_replicas_count=$(linstor -m --output-version=v1 resource list -r ${resource_name} | jq -r  --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[][] | select(.props.StorPoolName == $disklessStorPoolName).name] | length')
+      RESOURCE_NODES=$(linstor -m --output-version=v1 resource list-volumes  -r "${resource_name}" | jq '[.[][] | {node_name: .node_name, storage_pool: .volumes[0].storage_pool_name, allocated_size_kib: .volumes[0].allocated_size_kib}]')
+      ((count++))
+      if [[ -z $RESOURCE_NODES ]]; then
+        echo "Warning! Can't get RESOURCE_NODES for resource ${resource_name}."
+        echo "Resource status:"
+        exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+        if get_user_confirmation "Perform recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+          echo "Waiting $TIMEOUT_SEC seconds before retrying to get RESOURCE_NODES for the resource ${resource_name}."
+          sleep $TIMEOUT_SEC
+        else
+          exit_function
+        fi
+      else
+        break
+      fi
+    done
+
+    if [ $count -eq $max_attempts ]; then
+      echo "Maximum number of attempts reached. Can't get RESOURCE_NODES for resource ${resource_name}."
+      echo "Resource status:"
+      exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+      if get_user_confirmation "Exit the script? If not, the script will continue and recheck for the total number of diskless replicas for resource ${resource_name}." "y" "n"; then
+        exit_function
+      else
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking the total number of diskless replicas for resource ${resource_name}"
+        sleep $TIMEOUT_SEC
+        continue
+      fi
+    fi
+    break
+  done
+
+
+  resource_storage_pools=$(echo $RESOURCE_NODES | jq 'group_by(.storage_pool) | map({storage_pool: .[0].storage_pool, count: length})')
+  diskful_storage_pools_count=$(echo $resource_storage_pools | jq --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[] | select(.storage_pool != $disklessStorPoolName)] | length')
+  if (( diskful_storage_pools_count > 1 )); then
+    echo "Error: More than one diskful storage pool found for resource ${resource_name}."
+    echo $RESOURCE_NODES
+    exit 1
+  fi
+
+  diskful_replicas_count=$(echo $RESOURCE_NODES | jq --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[] | select(.storage_pool != $disklessStorPoolName)] | length')
+  diskless_replicas_count=$(echo $RESOURCE_NODES | jq --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[] | select(.storage_pool == $disklessStorPoolName)] | length')
+
+  if (( ${diskless_replicas_count} < 1 && ${diskful_replicas_count} == 2)); then
+    echo "The count of diskless replicas is ${diskless_replicas_count} and count of diskful replicas is ${diskful_replicas_count}. Creating a TieBreaker for resource ${resource_name}"
+
+    eval "$(get_sorted_free_nodes "$RESOURCE_NODES" "$ALL_STORAGE_POOLS_NODES" "${DISKLESS_STORAGE_POOL}")"
+    free_node_count=${#sorted_free_nodes[@]}
+    if [ 0 -ge ${free_node_count} ]; then
+      echo "Error: Not enough free nodes for create tiebreaker"
+      echo "sorted_free_nodes=${sorted_free_nodes[@]}"
+      echo "free_node_count=${free_node_count}"
+      
+      exit_function
+      return
+    fi
+
+    rand_index=$((RANDOM % free_node_count))
+    node_name=$(echo ${sorted_free_nodes[$rand_index]} | cut -d' ' -f2)
+    echo "Node ${node_name} has been selected for TieBreaker creation for resource ${resource_name}. Creating TieBreaker(diskless replica) on this node."
+
+    linstor_check_faulty
+    exec_linstor_with_exit_code_check resource-definition set-property $resource_name DrbdOptions/auto-add-quorum-tiebreaker true
+    sleep 5
+
+    while true; do
+      count=0
+      max_attempts=10
+      until [ $count -eq $max_attempts ]; do
+        diskless_replicas_count_new=$(linstor -m --output-version=v1 resource list -r ${resource_name} | jq -r  --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '[.[][] | select(.props.StorPoolName == $disklessStorPoolName).name] | length')
+        ((count++))
+        if [[ -z $diskless_replicas_count_new ]]; then
+          echo "Warning! Can't get the total number of diskless replicas for resource ${resource_name}."
+          echo "Resource status:"
+          exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+          if get_user_confirmation "Perform recheck in $TIMEOUT_SEC seconds?" "y" "n"; then
+            echo "Waiting $TIMEOUT_SEC seconds and rechecking the total number of diskless replicas for resource ${resource_name}"
+            sleep $TIMEOUT_SEC
+          else
+            exit_function
+          fi
+        else
+          break
+        fi
+      done
+
+      if [ $count -eq $max_attempts ]; then
+        echo "Maximum number of attempts reached. Can't get the total number of diskless replicas for resource ${resource_name}."
+        echo "Resource status:"
+        exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+        if get_user_confirmation "Exit the script? If not, the script will continue and recheck for the total number of diskless replicas for resource ${resource_name}." "y" "n"; then
+          exit_function
+        else
+          echo "Waiting $TIMEOUT_SEC seconds and rechecking the total number of diskless replicas for resource ${resource_name}"
+          sleep $TIMEOUT_SEC
+          continue
+        fi
+      fi
+      break
+    done
+
+    if (( ${diskless_replicas_count_new} < 1 )); then
+      # linstor resource create ${node_name} ${resource_name} --storage-pool ${DISKLESS_STORAGE_POOL} --drbd-diskless
+      echo "Warning! TieBreaker for the resource did not created after enabling auto-add-quorum-tiebreaker. Manual action required. Resource status:"
+      exec_linstor_with_exit_code_check resource list-volumes -r $resource_name
+      exit_function
+    fi
+  else
+    echo "The count of diskless replicas is ${diskless_replicas_count}. TieBreaker for resource ${resource_name} is not needed."
+  fi
+}
+
+
+
+wait_for_deployment_scale_down() {
+  local DEPLOYMENT_NAME=$1
+  local NAMESPACE=$2
+
+  local count=0
+  local max_attempts=60
+
+  until [[ $(kubectl get pods -n "$NAMESPACE" -l app="$DEPLOYMENT_NAME" --no-headers 2>/dev/null | wc -l) -eq 0 ]] || [[ $count -eq $max_attempts ]]; do
+    echo "Waiting for pods to be deleted... Attempt $((count+1))/$max_attempts."
+    sleep 5
+    ((count++))
+  done
+  
+  if [[ $count -eq $max_attempts ]]; then
+    echo "Timeout reached. Pods were not deleted."
+    exit_function
+    return
+  fi
+  echo "Pods were deleted."
+
+}
+
+linstor_backup_database() {
+  echo "Performing database backup"
+  
+  while true; do
+    count=0
+    max_attempts=10
+    until [ $count -eq $max_attempts ]; do
+      echo "Checking the number of replicas for LINSTOR controller and sds-replicated-volume-controller"
+      linstor_controller_current_replicas=$(kubectl -n ${LINSTOR_NAMESPACE} get deployment linstor-controller -o jsonpath='{.spec.replicas}')
+      sds_replicated_volume_controller_current_replicas=$(kubectl -n ${LINSTOR_NAMESPACE} get deployment sds-replicated-volume-controller -o jsonpath='{.spec.replicas}')
+      ((count++))
+      if [[ -z "${linstor_controller_current_replicas}" || -z "${sds_replicated_volume_controller_current_replicas}" ]]; then
+        echo "Can't get the number of replicas for LINSTOR controller or sds-replicated-volume-controller."
+        if get_user_confirmation "Should we recheck the number of replicas for the LINSTOR controller and sds-replicated-volume-controller after $TIMEOUT_SEC seconds? (Note that the database backup will not be performed if this is not done.)" "y" "n"; then
+          echo "Waiting $TIMEOUT_SEC seconds and rechecking the number of replicas for LINSTOR controller and sds-replicated-volume-controller"
+          sleep $TIMEOUT_SEC
+          continue
+        else
+          exit_function
+        fi
+      else
+        break
+      fi
+    done
+
+    if [ $count -eq $max_attempts ]; then
+      echo "Timeout reached. Can't get the number of replicas for LINSTOR controller or sds-replicated-volume-controller."
+      if get_user_confirmation "Exit the script? If not, the script will continue and recheck for the number of replicas for LINSTOR controller and sds-replicated-volume-controller." "y" "n"; then
+        exit_function
+      else
+        echo "Waiting $TIMEOUT_SEC seconds and rechecking the number of replicas for LINSTOR controller and sds-replicated-volume-controller"
+        sleep $TIMEOUT_SEC
+        continue
+      fi
+    fi
+    break
+  done
+
+  echo "Scale down sds-replicated-volume-controller and LINSTOR controller"
+  execute_command "kubectl -n ${LINSTOR_NAMESPACE} scale deployment sds-replicated-volume-controller --replicas=0"
+  echo "Waiting for sds-replicated-volume-controller to scale down"
+  wait_for_deployment_scale_down "sds-replicated-volume-controller" "${LINSTOR_NAMESPACE}"
+
+  execute_command "kubectl -n ${LINSTOR_NAMESPACE} scale deployment linstor-controller --replicas=0"
+  echo "Waiting for LINSTOR controller to scale down"
+  wait_for_deployment_scale_down "linstor-controller" "${LINSTOR_NAMESPACE}"
+
+  echo "Creating a backup of the LINSTOR database"
+  export current_datetime=$(date +%Y-%m-%d_%H-%M-%S)
+  mkdir linstor_db_backup_before_replicas_manager_${current_datetime}
+  kubectl get crds | grep -o ".*.internal.linstor.linbit.com" | xargs kubectl get crds -oyaml > ./linstor_db_backup_before_replicas_manager_${current_datetime}/crds.yaml
+  kubectl get crds | grep -o ".*.internal.linstor.linbit.com" | xargs -i{} sh -xc "kubectl get {} -oyaml > ./linstor_db_backup_before_replicas_manager_${current_datetime}/{}.yaml"
+  echo "Database backup completed"
+  echo "Scale up LINSTOR controller and sds-replicated-volume-controller"
+  execute_command "kubectl -n ${LINSTOR_NAMESPACE} scale deployment sds-replicated-volume-controller --replicas=${sds_replicated_volume_controller_current_replicas}"
+  execute_command "kubectl -n ${LINSTOR_NAMESPACE} scale deployment linstor-controller --replicas=${linstor_controller_current_replicas}"
+  echo "Waiting for LINSTOR controller to scale up"
+  sleep 15
+  linstor_check_faulty
+}
+
+
+#####################################
+################ MAIN ###############
+#####################################
+linstor_check_faulty
+linstor_check_connection
+linstor_wait_sync 0
+
+
+linstor_backup_database
+
+DISKFUL_RESOURCES=$(linstor -m --output-version=v1 resource-definition list | jq -r .[][].name)
+RESOURCE_AND_GROUP_NAMES=$(linstor -m --output-version=v1 resource-definition list -r ${DISKFUL_RESOURCES} | jq -r '.[][] | {resource: .name, resource_group: .resource_group_name}')
+RESOURCE_GROUPS=$(linstor -m --output-version=v1 resource-group list | jq -r '.[][] | {resource_group: .name, place_count: .select_filter.place_count}')
+ALL_STORAGE_POOLS_NODES=$(linstor -m --output-version=v1 storage-pool list | jq  '[.[][] | {storage_pool_name: .storage_pool_name, node_name: .node_name, free_capacity: .free_capacity}]')
+
+linstor_change_replicas_count 0 5 "${RESOURCE_AND_GROUP_NAMES}" "${RESOURCE_GROUPS}" "${DISKFUL_RESOURCES[@]}" 
+echo "Increase in replica count for movable resources completed"
+
+
+# If any replica here got stuck in Inconsistent, then the following can be done:
+## Deactivate and subsequently activate the resource on the node where synchronization got stuck
+## If that didn't help, then remove the replica on the problematic node and manually create it on another node with the command linstor r create <node name> <resource name>
+
+echo "Status of processed resources"
+exec_linstor_with_exit_code_check resource list-volumes -r ${DISKFUL_RESOURCES}
+sleep 2
+
+
+linstor_check_faulty
+linstor_wait_sync 0
+linstor_check_faulty
+linstor_check_advise
+
+echo "Script operation completed"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR introduces a new script, `replicas_manager.sh`. The script is designed to manage and automate tasks related to LINSTOR replicas.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `replicas_manager.sh` script simplifies the management of Linstor replicas by automating common tasks. Specifically, it checks the number of diskful replicas for each resource and, if there are fewer than required, creates the necessary number of additional diskful replicas.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
