### PR TITLE
[linstor] Add "resource activate/deactivate" to allowed commands in client-wrapper.sh script

### DIFF
--- a/images/linstor-server/client-wrapper.sh
+++ b/images/linstor-server/client-wrapper.sh
@@ -100,6 +100,10 @@ if [[ $(echo "${valid_subcommands_list[@]}" | fgrep -w -- $1) ]]; then
     allowed=true
   fi
 
+  if [[ "$2" == "activate" || "$2" == "deactivate" ]]; then
+    allowed=true
+  fi
+
   if [[ "$2" == "set-property" ]] && [[ "$4" == "AutoplaceTarget" ]]; then
     allowed=true
   fi


### PR DESCRIPTION
## Description

Add `resource activate/deactivate` to allowed commands.

## Why do we need it, and what problem does it solve?

This is needed to recover from possible disk outages.

## What is the expected result?

Command `resource activate/deactivate` can be used by users.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
