### PR TITLE
[docs] Change the DRBD module status to `deprecated`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ __pycache__/
 # dev
 images/sds-drbd-controller/dev/Dockerfile-dev
 images/sds-drbd-controller/Makefile
+images/sds-replicated-volume-controller/Makefile

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,7 +4,7 @@ force_searchable: true
 description: The sds-drbd Deckhouse module's configuration.
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {{< /alert >}}
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,7 +5,7 @@ description: The sds-drbd Deckhouse module's configuration.
 ---
 
 {% alert level="danger" %}
-This version of the module is deprecated and is no longer supported. Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
+Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {% endalert %}
 
 {{< alert level="warning" >}}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,9 +4,9 @@ force_searchable: true
 description: The sds-drbd Deckhouse module's configuration.
 ---
 
-{% alert level="danger" %}
+{{< alert level="danger" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
-{% endalert %}
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 The module is guaranteed to work only in the following cases:

--- a/docs/CONFIGURATION_RU.md
+++ b/docs/CONFIGURATION_RU.md
@@ -5,7 +5,7 @@ description: Параметры настройки модуля sds-drbd Deckhou
 ---
 
 {% alert level="danger" %}
-Текущая версия модуля устарела и больше не поддерживается. Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
+Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {% endalert %}
 
 {{< alert level="warning" >}}

--- a/docs/CONFIGURATION_RU.md
+++ b/docs/CONFIGURATION_RU.md
@@ -4,9 +4,9 @@ force_searchable: true
 description: Параметры настройки модуля sds-drbd Deckhouse.
 ---
 
-{% alert level="danger" %}
+{{< alert level="danger" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
-{% endalert %}
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 Работоспособность модуля гарантируется только в следующих случаях:

--- a/docs/CONFIGURATION_RU.md
+++ b/docs/CONFIGURATION_RU.md
@@ -4,7 +4,7 @@ force_searchable: true
 description: Параметры настройки модуля sds-drbd Deckhouse.
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {{< /alert >}}
 

--- a/docs/CR.md
+++ b/docs/CR.md
@@ -3,9 +3,9 @@ title: "The sds-drbd module: Custom Resources"
 description: "The sds-drbd module Custom Resources: DRBDStoragePool and DRBDStorageClass."
 ---
 
-{% alert level="danger" %}
-This version of the module is deprecated and is no longer supported. Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
-{% endalert %}
+{{< alert level="danger" >}}
+Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 The module is guaranteed to work only in the following cases:

--- a/docs/CR.md
+++ b/docs/CR.md
@@ -3,7 +3,7 @@ title: "The sds-drbd module: Custom Resources"
 description: "The sds-drbd module Custom Resources: DRBDStoragePool and DRBDStorageClass."
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {{< /alert >}}
 

--- a/docs/CR_RU.md
+++ b/docs/CR_RU.md
@@ -3,7 +3,7 @@ title: "Модуль sds-drbd: Custom Resources"
 description: "Модуль sds-drbd Custom Resources: DRBDStoragePool и DRBDStorageClass."
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {{< /alert >}}
 

--- a/docs/CR_RU.md
+++ b/docs/CR_RU.md
@@ -3,9 +3,9 @@ title: "Модуль sds-drbd: Custom Resources"
 description: "Модуль sds-drbd Custom Resources: DRBDStoragePool и DRBDStorageClass."
 ---
 
-{% alert level="danger" %}
-Текущая версия модуля устарела и больше не поддерживается. Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
-{% endalert %}
+{{< alert level="danger" >}}
+Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 Работоспособность модуля гарантируется только в следующих случаях:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,7 @@
 title: "The sds-drbd module: FAQ"
 description: LINSTOR Troubleshooting. What is difference between LVM and LVMThin? LINSTOR performance and reliability notes, comparison to Ceph. How to add existing LINSTOR LVM or LVMThin pool. How to configure Prometheus to use LINSTOR for storing data. Controller's work-flow questions.
 ---
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {{< /alert >}}
 
@@ -295,7 +295,7 @@ alias linstor='kubectl -n d8-sds-drbd exec -ti deploy/linstor-controller -- lins
 linstor resource list --faulty
 ```
 
-{% alert level="danger" %}
+{% alert level="warning" %}
 This version of the module is deprecated and is no longer supported. Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {% endalert %}
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,6 +2,9 @@
 title: "The sds-drbd module: FAQ"
 description: LINSTOR Troubleshooting. What is difference between LVM and LVMThin? LINSTOR performance and reliability notes, comparison to Ceph. How to add existing LINSTOR LVM or LVMThin pool. How to configure Prometheus to use LINSTOR for storing data. Controller's work-flow questions.
 ---
+{{< alert level="danger" >}}
+Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 The module is guaranteed to work only in the following cases:

--- a/docs/FAQ_RU.md
+++ b/docs/FAQ_RU.md
@@ -3,9 +3,9 @@ title: "Модуль sds-drbd: FAQ"
 description: Диагностика проблем LINSTOR. Когда следует использовать LVM, а когда LVMThin? Производительность и надежность LINSTOR, сравнение с Ceph. Как добавить существующий LVM или LVMThin-пул в LINSTOR? Как настроить Prometheus на использование хранилища LINSTOR? Вопросы по работе контроллера.
 ---
 
-{% alert level="danger" %}
-Текущая версия модуля устарела и больше не поддерживается. Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
-{% endalert %}
+{{< alert level="danger" >}}
+Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 Работоспособность модуля гарантируется только в следующих случаях:

--- a/docs/FAQ_RU.md
+++ b/docs/FAQ_RU.md
@@ -3,7 +3,7 @@ title: "Модуль sds-drbd: FAQ"
 description: Диагностика проблем LINSTOR. Когда следует использовать LVM, а когда LVMThin? Производительность и надежность LINSTOR, сравнение с Ceph. Как добавить существующий LVM или LVMThin-пул в LINSTOR? Как настроить Prometheus на использование хранилища LINSTOR? Вопросы по работе контроллера.
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {{< /alert >}}
 

--- a/docs/LAYOUTS.md
+++ b/docs/LAYOUTS.md
@@ -3,7 +3,7 @@ title: "Module sds-drbd: use cases"
 linkTitle: "Usage cases"
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {{< /alert >}}
 

--- a/docs/LAYOUTS.md
+++ b/docs/LAYOUTS.md
@@ -3,9 +3,9 @@ title: "Module sds-drbd: use cases"
 linkTitle: "Usage cases"
 ---
 
-{% alert level="danger" %}
-This version of the module is deprecated and is no longer supported. Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
-{% endalert %}
+{{< alert level="danger" >}}
+Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 The module is guaranteed to work only in the following cases:

--- a/docs/LAYOUTS_RU.md
+++ b/docs/LAYOUTS_RU.md
@@ -3,7 +3,7 @@ title: "Модуль sds-drbd: Сценарии использования"
 linkTitle: "Сценарии использования"
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {{< /alert >}}
 

--- a/docs/LAYOUTS_RU.md
+++ b/docs/LAYOUTS_RU.md
@@ -3,9 +3,9 @@ title: "Модуль sds-drbd: Сценарии использования"
 linkTitle: "Сценарии использования"
 ---
 
-{% alert level="danger" %}
-Текущая версия модуля устарела и больше не поддерживается. Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
-{% endalert %}
+{{< alert level="danger" >}}
+Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 Работоспособность модуля гарантируется только в следующих случаях:

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@ description: "The sds-drbd module: General Concepts and Principles."
 moduleStatus: deprecated
 ---
 
-{% alert level="danger" %}
+{{< alert level="danger" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
-{% endalert %}
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 The module is guaranteed to work only in the following cases:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ moduleStatus: deprecated
 ---
 
 {% alert level="danger" %}
-This version of the module is deprecated and is no longer supported. Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
+Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {% endalert %}
 
 {{< alert level="warning" >}}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ description: "The sds-drbd module: General Concepts and Principles."
 moduleStatus: deprecated
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {{< /alert >}}
 

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -5,7 +5,7 @@ moduleStatus: deprecated
 ---
 
 {% alert level="danger" %}
-Текущая версия модуля устарела и больше не поддерживается. Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
+Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {% endalert %}
 
 {{< alert level="warning" >}}

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -4,7 +4,7 @@ description: "Модуль sds-drbd: общие концепции и полож
 moduleStatus: deprecated
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {{< /alert >}}
 

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -4,9 +4,9 @@ description: "Модуль sds-drbd: общие концепции и полож
 moduleStatus: deprecated
 ---
 
-{% alert level="danger" %}
+{{< alert level="danger" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
-{% endalert %}
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 Работоспособность модуля гарантируется только в следующих случаях:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -3,9 +3,9 @@ title: "The sds-drbd module: configuration examples"
 description: The sds-drbd controller usage and work-flow examples.
 ---
 
-{% alert level="danger" %}
-This version of the module is deprecated and is no longer supported. Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
-{% endalert %}
+{{< alert level="danger" >}}
+Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 The module is guaranteed to work only in the following cases:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -3,7 +3,7 @@ title: "The sds-drbd module: configuration examples"
 description: The sds-drbd controller usage and work-flow examples.
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Use the [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/) module instead.
 {{< /alert >}}
 

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -3,7 +3,7 @@ title: "Модуль sds-drbd: примеры конфигурации"
 description: "Использование и примеры работы sds-drbd-controller."
 ---
 
-{{< alert level="danger" >}}
+{{< alert level="warning" >}}
 Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
 {{< /alert >}}
 

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -3,9 +3,9 @@ title: "Модуль sds-drbd: примеры конфигурации"
 description: "Использование и примеры работы sds-drbd-controller."
 ---
 
-{% alert level="danger" %}
-Текущая версия модуля устарела и больше не поддерживается. Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
-{% endalert %}
+{{< alert level="danger" >}}
+Переключитесь на использование модуля [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
+{{< /alert >}}
 
 {{< alert level="warning" >}}
 Работоспособность модуля гарантируется только в следующих случаях:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change the module status from `experimental` to `deprecated`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We change the name of the module to `sds-replicated-volume`. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

The status of the module in the documentation is `deprecated `.
