### PR TITLE
[monitoring] Fix namespace in `D8DrbdPeerDeviceIsOutOfSync` alert description

### DIFF
--- a/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/monitoring/prometheus-rules/drbd-devices.yaml
@@ -70,7 +70,7 @@
           1. Login into node with the problem:
 
              ```
-             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
+             kubectl -n d8-sds-replicated-volume exec -ti $(kubectl -n d8-sds-replicated-volume get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
              ```
 
           2. Check the LINSTOR peer node state:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR corrects the namespace in the description of the D8DrbdPeerDeviceIsOutOfSync alert. The previous namespace was incorrect, causing confusion during monitoring and alerting processes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The main goal of this change is to ensure the accuracy of alert descriptions, which is crucial for effective monitoring and quick issue resolution. By fixing the namespace in the D8DrbdPeerDeviceIsOutOfSync alert description, we eliminate potential confusion and improve the clarity of alerts.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

After applying these changes, the description of the D8DrbdPeerDeviceIsOutOfSync alert will reflect the correct namespace. There should be no more confusion regarding the source of this alert, leading to more efficient monitoring and troubleshooting.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
