### PR TITLE
[controller] Add `quorum-minimum-redundancy` for `ConsistencyAndAvailability` ReplicatedStorageClass

### DIFF
--- a/images/sds-replicated-volume-controller/Dockerfile
+++ b/images/sds-replicated-volume-controller/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_GOLANG_ALPINE=registry.deckhouse.io/base_images/golang:1.22.1-alpine@sha256:0de6cf7cceab6ecbf0718bdfb675b08b78113c3709c5e4b99456cdb2ae8c2495
+ARG BASE_GOLANG_22_ALPINE=registry.deckhouse.io/base_images/golang:1.22.1-alpine@sha256:0de6cf7cceab6ecbf0718bdfb675b08b78113c3709c5e4b99456cdb2ae8c2495
 
-FROM $BASE_GOLANG_ALPINE as builder
+FROM $BASE_GOLANG_22_ALPINE as builder
 
 WORKDIR /go/src
 
@@ -14,7 +14,7 @@ COPY . .
 WORKDIR /go/src/cmd
 RUN GOOS=linux GOARCH=amd64 go build -o stctrl
 
-FROM --platform=linux/amd64 $BASE_GOLANG_ALPINE
+FROM --platform=linux/amd64 $BASE_GOLANG_22_ALPINE
 COPY --from=builder /go/src/tools /tools
 COPY --from=builder /go/src/cmd/stctrl /go/src/cmd/stctrl
 

--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_node.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_node.go
@@ -299,8 +299,7 @@ func addDriverToCSINode(ctx context.Context, cl client.Client, csiNode *storagev
 func removeDriverFromCSINode(ctx context.Context, cl client.Client, csiNode *storagev1.CSINode, driverName string) error {
 	for i, driver := range csiNode.Spec.Drivers {
 		if driver.Name == driverName {
-			csiDriversAfterDelete := slices.Delete(csiNode.Spec.Drivers, i, i+1)
-			csiNode.Spec.Drivers = csiDriversAfterDelete
+			csiNode.Spec.Drivers = slices.Delete(csiNode.Spec.Drivers, i, i+1)
 		}
 	}
 	err := cl.Update(ctx, csiNode)

--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_node.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_node.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	storagev1 "k8s.io/api/storage/v1"
 	"net"
 	"reflect"
 	sdsapi "sds-replicated-volume-controller/api/v1alpha1"
@@ -27,6 +26,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	storagev1 "k8s.io/api/storage/v1"
 
 	lclient "github.com/LINBIT/golinstor/client"
 	"gopkg.in/yaml.v3"
@@ -298,7 +299,8 @@ func addDriverToCSINode(ctx context.Context, cl client.Client, csiNode *storagev
 func removeDriverFromCSINode(ctx context.Context, cl client.Client, csiNode *storagev1.CSINode, driverName string) error {
 	for i, driver := range csiNode.Spec.Drivers {
 		if driver.Name == driverName {
-			slices.Delete(csiNode.Spec.Drivers, i, i+1)
+			csiDriversAfterDelete := slices.Delete(csiNode.Spec.Drivers, i, i+1)
+			csiNode.Spec.Drivers = csiDriversAfterDelete
 		}
 	}
 	err := cl.Update(ctx, csiNode)

--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
@@ -165,8 +165,7 @@ func ReconcileParams(
 				if slices.Contains(missMatched, quorumMinimumRedundancyWithoutPrefixKey) && sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey] != "" {
 					log.Info(fmt.Sprintf("[ReconcileParams] the quorum-minimum-redundancy value is set in the Storage Class %s, value: %s, but it is not match the Resource Group %s value %s", sc.Name, sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey], rg.Name, rg.Props[quorumMinimumRedundancyWithPrefixRGKey]))
 					log.Info(fmt.Sprintf("[ReconcileParams] the quorum-minimum-redundancy value will be set to the Resource Group %s, value: %s", rg.Name, sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey]))
-					// err = setQuorumMinimumRedundancy(ctx, lc, sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey], rg.Name)
-					err = setQuorumMinimumRedundancy(ctx, lc, "s", rg.Name)
+					err = setQuorumMinimumRedundancy(ctx, lc, sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey], rg.Name)
 
 					if err != nil {
 						log.Error(err, fmt.Sprintf("[ReconcileParams] unable to set the quorum-minimum-redundancy value, name: %s", pv.Name))

--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
@@ -45,7 +45,8 @@ const (
 	replicasOnSameRGKey                     = "replicas_on_same"
 	replicasOnDifferentRGKey                = "replicas_on_different"
 	quorumMinimumRedundancyWithoutPrefixKey = "quorum-minimum-redundancy"
-	quorumMinimumRedundancyWithPrefixKey    = "DrbdOptions/Resource/quorum-minimum-redundancy"
+	quorumMinimumRedundancyWithPrefixRGKey  = "DrbdOptions/Resource/quorum-minimum-redundancy"
+	quorumMinimumRedundancyWithPrefixSCKey  = "property.linstor.csi.linbit.com/DrbdOptions/Resource/quorum-minimum-redundancy"
 	replicasOnSameSCKey                     = "replicasOnSame"
 	replicasOnDifferentSCKey                = "replicasOnDifferent"
 	placementCountSCKey                     = "placementCount"
@@ -161,10 +162,10 @@ func ReconcileParams(
 					labelsToAdd = map[string]string{missMatchedLabel: "true"}
 				}
 
-				if slices.Contains(missMatched, quorumMinimumRedundancyWithoutPrefixKey) && sc.Parameters[quorumMinimumRedundancyWithPrefixKey] != "" {
-					log.Info(fmt.Sprintf("[ReconcileParams] the quorum-minimum-redundancy value is set in the Storage Class %s, value: %s, but it is not match the Resource Group %s value %s", sc.Name, sc.Parameters[quorumMinimumRedundancyWithPrefixKey], rg.Name, rg.Props[quorumMinimumRedundancyWithPrefixKey]))
-					log.Info(fmt.Sprintf("[ReconcileParams] the quorum-minimum-redundancy value will be set to the Resource Group %s, value: %s", rg.Name, sc.Parameters[quorumMinimumRedundancyWithPrefixKey]))
-					err = setQuorumMinimumRedundancy(ctx, lc, sc.Parameters[quorumMinimumRedundancyWithPrefixKey], rg.Name)
+				if slices.Contains(missMatched, quorumMinimumRedundancyWithoutPrefixKey) && sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey] != "" {
+					log.Info(fmt.Sprintf("[ReconcileParams] the quorum-minimum-redundancy value is set in the Storage Class %s, value: %s, but it is not match the Resource Group %s value %s", sc.Name, sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey], rg.Name, rg.Props[quorumMinimumRedundancyWithPrefixRGKey]))
+					log.Info(fmt.Sprintf("[ReconcileParams] the quorum-minimum-redundancy value will be set to the Resource Group %s, value: %s", rg.Name, sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey]))
+					err = setQuorumMinimumRedundancy(ctx, lc, sc.Parameters[quorumMinimumRedundancyWithPrefixSCKey], rg.Name)
 					if err != nil {
 						log.Error(err, fmt.Sprintf("[ReconcileParams] unable to set the quorum-minimum-redundancy value, name: %s", pv.Name))
 						labelsToAdd = map[string]string{unableToSetQuorumMinimumRedundancyLabel: "true"}
@@ -536,7 +537,7 @@ func setQuorumMinimumRedundancy(ctx context.Context, lc *lapi.Client, value, rgN
 
 	err = lc.ResourceGroups.Modify(ctx, rgName, lapi.ResourceGroupModify{
 		OverrideProps: map[string]string{
-			quorumMinimumRedundancyWithPrefixKey: strconv.Itoa(quorumMinimumRedundancy),
+			quorumMinimumRedundancyWithPrefixRGKey: strconv.Itoa(quorumMinimumRedundancy),
 		},
 	})
 

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -498,6 +498,7 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *v1alpha1.Repli
 		storageClassParameters[StorageClassPlacementCountKey] = "3"
 		storageClassParameters[StorageClassAutoEvictMinReplicaCountKey] = "3"
 		storageClassParameters[StorageClassParamAutoQuorumKey] = SuspendIo
+		storageClassParameters[quorumMinimumRedundancyWithPrefixSCKey] = "3"
 	}
 
 	var volumeBindingMode storagev1.VolumeBindingMode

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -515,7 +515,7 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *v1alpha1.Repli
 		storageClassParameters[StorageClassPlacementCountKey] = "3"
 		storageClassParameters[StorageClassAutoEvictMinReplicaCountKey] = "3"
 		storageClassParameters[StorageClassParamAutoQuorumKey] = SuspendIo
-		storageClassParameters[quorumMinimumRedundancyWithPrefixSCKey] = "3"
+		storageClassParameters[quorumMinimumRedundancyWithPrefixSCKey] = "2"
 	}
 
 	var volumeBindingMode storagev1.VolumeBindingMode

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -694,6 +694,7 @@ func ReconcileStorageClassLabels(ctx context.Context, cl client.Client, storageC
 func canRecreateStorageClass(replicatedSC *v1alpha1.ReplicatedStorageClass, oldSC *storagev1.StorageClass) bool {
 	newSC := GenerateStorageClassFromReplicatedStorageClass(replicatedSC)
 	delete(newSC.Parameters, quorumMinimumRedundancyWithPrefixSCKey)
+	delete(oldSC.Parameters, quorumMinimumRedundancyWithPrefixSCKey)
 	equal, _ := CompareStorageClasses(newSC, oldSC)
 	return equal
 }

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -854,7 +854,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		replicatedSC.Status.Phase = controller.Created
 		storageClass := controller.GenerateStorageClassFromReplicatedStorageClass(&replicatedSC)
 
-		equal, _ := controller.CompareReplicatedStorageClassAndStorageClass(&replicatedSC, storageClass)
+		equal, _ := controller.CompareStorageClasses(&replicatedSC, storageClass)
 		Expect(equal).To(BeTrue())
 	})
 
@@ -874,7 +874,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 			VolumeBindingMode: &diffVBM,
 		}
 
-		equal, message := controller.CompareReplicatedStorageClassAndStorageClass(&replicatedSC, storageClass)
+		equal, message := controller.CompareStorageClasses(&replicatedSC, storageClass)
 		Expect(equal).To(BeFalse())
 		Expect(message).To(Equal("ReplicatedStorageClass and StorageClass are not equal: Parameters are not equal; Provisioner are not equal(ReplicatedStorageClass: linstor.csi.linbit.com, StorageClass: not-equal); ReclaimPolicy are not equal(ReplicatedStorageClass: Retain, StorageClass: not-equalVolumeBindingMode are not equal(ReplicatedStorageClass: WaitForFirstConsumer, StorageClass: not-equal); "))
 	})

--- a/monitoring/prometheus-rules/replicated-pv-with-incorrect-settings.yaml
+++ b/monitoring/prometheus-rules/replicated-pv-with-incorrect-settings.yaml
@@ -22,3 +22,19 @@
           
           Also, you can add label for all incorrect PVs
           `kubectl label pv -l storage.deckhouse.io/linstor-settings-mismatch=true storage.deckhouse.io/linstor-settings-mismatch-ignore=true`
+    - alert: ReplicatedPVWithIncorrectQuorumMinimumRedundancy
+      expr: count(kube_persistentvolume_labels{label_storage_deckhouse_io_unable_to_set_quorum_minimum_redundancy="true"}) > 0
+      for: 5m
+      labels:
+        severity_level: "3"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_drbd_device_health: "ReplicatedPVSettingsCheck,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_drbd_device_health: "ReplicatedPVSettingsCheck,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: Replicated PVs has incorrect quorum-minimum-redundancy setting
+        description: |
+          There are persistent volumes in the cluster that has incorrect quorum-minimum-redundancy setting.
+          
+          Please, contact tech support for assistance.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR adds the `quorum-minimum-redundancy` parameter set to 2 in the storage class when `replication=ConsistencyAndAvailability` (which creates PVs with 3 diskful replicas).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `quorum-minimum-redundancy` parameter ensures that a volume can maintain quorum with a minimum number of redundant replicas. This is crucial for data consistency and availability in DRBD clusters. Setting it to 2 guarantees that the system can tolerate the failure of one node while still maintaining data integrity.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- The `quorum-minimum-redundancy` parameter is set to 2 in the storage class for `ConsistencyAndAvailability`.
- The setting is applied in LINSTOR and verified for each PV.
- If the setting cannot be applied, an alert `ReplicatedPVWithIncorrectQuorumMinimumRedundancy` is triggered.

## Downsides:
- For LVM thick volumes, PVs do not mount in pods immediately and wait for the initial sync to complete.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
