### PR TITLE
[linstor] Improve efficiency of replicas_manager.sh by batching resource queries

### DIFF
--- a/images/sds-replicated-volume-controller/tools/evict.sh
+++ b/images/sds-replicated-volume-controller/tools/evict.sh
@@ -813,7 +813,7 @@ kubernetes_check_node() {
   else
     echo "The cordon command has not been executed for node ${NODE_FOR_EVICT}."
     if get_user_confirmation "Perform node drain? (if confirmed, the command \"kubectl drain ${NODE_FOR_EVICT} --delete-emptydir-data  --ignore-daemonsets\" will be executed)" "y" "n"; then
-      execute_command "kubectl drain ${NODE_FOR_EVICT} --delete-emptydir-data  --ignore-daemonsets"
+      execute_command "kubectl drain ${NODE_FOR_EVICT} --delete-emptydir-data  --ignore-daemonsets --force"
       echo "Drain of node ${NODE_FOR_EVICT} completed"
       return 0
     else

--- a/images/sds-replicated-volume-controller/tools/evict.sh
+++ b/images/sds-replicated-volume-controller/tools/evict.sh
@@ -813,7 +813,7 @@ kubernetes_check_node() {
   else
     echo "The cordon command has not been executed for node ${NODE_FOR_EVICT}."
     if get_user_confirmation "Perform node drain? (if confirmed, the command \"kubectl drain ${NODE_FOR_EVICT} --delete-emptydir-data  --ignore-daemonsets\" will be executed)" "y" "n"; then
-      execute_command "kubectl drain ${NODE_FOR_EVICT} --delete-emptydir-data  --ignore-daemonsets --force"
+      execute_command "kubectl drain ${NODE_FOR_EVICT} --delete-emptydir-data  --ignore-daemonsets"
       echo "Drain of node ${NODE_FOR_EVICT} completed"
       return 0
     else


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR modifies the logic of the `replicas_manager.sh` script. Previously, the data for the `RESOURCE_AND_GROUP_NAMES` variable (which stores the mapping of resource names to their resource groups) was fetched in a single request from LINSTOR. With a large number of resources, LINSTOR returned an error. Now, multiple requests are made, each fetching data for 10 resources at a time.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fetching data for a large number of resources in a single request from LINSTOR caused errors due to the excessive load. By batching the requests to handle 10 resources at a time, we reduce the load on LINSTOR, preventing errors and ensuring reliable operation of the `replicas_manager.sh` script.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- The `replicas_manager.sh` script will be able to handle a large number of resources without encountering errors.
- Improved reliability and performance of the script when interacting with LINSTOR.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
