### PR TITLE
[DRBD] Fix DRBD build on ALT Linux and Ubuntu with kernel 6.5

### DIFF
--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -119,6 +119,7 @@ spec:
       fi
     fi
 
+    apt-get update
     apt-get -y install make gcc bind-utils patch mokutil
     check_sb_state="$(mokutil --sb-state || echo "Not supported")"
     if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -121,7 +121,9 @@ spec:
       fi
     fi
 
-    bb-apt-install make gcc bind9-host patch mokutil
+    # Check, if we need gcc version 12
+    gccVersion="$(cat /proc/version | grep -q x86_64-linux-gnu-gcc-12 && echo gcc-12 || echo gcc)"
+    bb-apt-install make bind9-host patch mokutil $gccVersion
     check_sb_state="$(mokutil --sb-state || echo "Not supported")"
     if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then
       bb-log-info "SecureBoot is enabled. Please manually install DRBD version  {{ $.Values.sdsReplicatedVolume.internal.drbdVersion }} or higher."


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix DRBD build on ALT Linux and Ubuntu with kernel 6.5

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We have problems with ALT Linux and Ubuntu with kernel v6.5

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct DRBD build

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
