### PR TITLE
[controller] Restrict pool creation on ephemeral nodes

### DIFF
--- a/images/linstor-server/client-wrapper.sh
+++ b/images/linstor-server/client-wrapper.sh
@@ -21,7 +21,8 @@ valid_subcommands_list=("storage-pool" "sp" "node" "n" "resource" "r" "volume" "
 valid_subcommands_ver=("controller" "c")
 valid_subcommands_lv=("resource" "r")
 valid_subcommands_advise=("advise" "adv")
-valid_subcommands_create_delete=("storage-pool" "node" "resource" "volume" "resource-definition")
+valid_subcommands_delete=("storage-pool")
+valid_subcommands_create_delete=("node" "resource" "volume" "resource-definition")
 valid_keys=("-m" "--output-version=v1")
 allowed=false
 
@@ -36,7 +37,8 @@ if [[ -z "$1" || "--help" == "$1" || "-h" == "$1" ]]; then
   echo "- controller version"
   echo "- advise resource/maintainance"
   echo "- resource-definition delete"
-  echo "- --yes-i-am-sane-and-i-understand-what-i-am-doing storage-pool/node/resource/volume/resource-definition create/delete (!key before command is required!)"
+  echo "- --yes-i-am-sane-and-i-understand-what-i-am-doing node/resource/volume/resource-definition create/delete (!key before command is required!)"
+  echo "- --yes-i-am-sane-and-i-understand-what-i-am-doing storage-pool delete (!key before command is required!)"
   exit 0
 fi
 
@@ -82,6 +84,13 @@ done
 # Allow dangerous commands (delete/create)
 if [[ $(echo "${valid_subcommands_create_delete[@]}" | fgrep -w -- $1) ]] && [[ $allowDangerousCommands == true ]]; then
   if [[ "$2" == "create" || "$2" == "delete" ]]; then
+    allowed=true
+  fi
+fi
+
+# Allow dangerous commands (delete)
+if [[ $(echo "${valid_subcommands_delete[@]}" | fgrep -w -- $1) ]] && [[ $allowDangerousCommands == true ]]; then
+  if [[ "$2" == "delete" ]]; then
     allowed=true
   fi
 fi

--- a/images/webhooks/src/main.go
+++ b/images/webhooks/src/main.go
@@ -52,8 +52,8 @@ func initFlags() config {
 
 const (
 	port           = ":8443"
-	RSPValidatorId = "RSPValidator"
 	RSCValidatorId = "RSCValidator"
+	RSPValidatorId = "RSPValidator"
 	SCValidatorId  = "SCValidator"
 )
 
@@ -84,8 +84,8 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.Handle("/rsc-validate", rscValidatingWebhookHandler)
-	mux.Handle("/rsp-validate", rspValidatingWebhookHandler)
 	mux.Handle("/sc-validate", scValidatingWebhookHandler)
+	mux.Handle("/rsp-validate", rspValidatingWebhookHandler)
 	mux.HandleFunc("/healthz", httpHandlerHealthz)
 
 	logger.Infof("Listening on %s", port)

--- a/monitoring/prometheus-rules/linstor-storage-pools.yaml
+++ b/monitoring/prometheus-rules/linstor-storage-pools.yaml
@@ -122,3 +122,18 @@
              kubectl exec -n d8-sds-replicated-volume deploy/linstor-controller -- linstor resource-definition wait-sync RESOURCE_NAME
              kubectl exec -n d8-sds-replicated-volume deploy/linstor-controller -- linstor --yes-i-am-sane-and-i-understand-what-i-am-doing resource delete OLD_NODE RESOURCE_NAME
              ```
+
+    - alert: D8LinstorStoragePoolOnEphemeralNode
+      expr: linstor_storage_pool_capacity_total_bytes * on(node) group_left() kube_node_labels{label_node_deckhouse_io_type="CloudEphemeral"} > 0
+      for: 5m
+      labels:
+        severity_level: "1"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: Storage pool on CloudEphemeral node
+        description: |
+          Diskful LINSTOR storage pool exists on CloudEphemeral node {{ $labels.node }}. This is dangerous situation, move data and remove this storage pull immediately


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Restrict pool creation on ephemeral nodes

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In case of storage pool exists on CloudEphemeral node, it can lead data loss

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Restricted CloudEphemeral diskful storage pool usage

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
