### PR TITLE
[controller] Enhance evict.sh logging and manage sds-replicated-volume-controller during eviction

### DIFF
--- a/images/sds-replicated-volume-controller/tools/evict.sh
+++ b/images/sds-replicated-volume-controller/tools/evict.sh
@@ -1266,8 +1266,13 @@ if [[ "${DELETE_MODE}" == "node" ]]; then
   fi
 elif [[ "${DELETE_MODE}" == "resources-only" ]]; then
   echo "Only the deletion of all resources from ${NODE_FOR_EVICT} will be executed. The node will NOT be deleted from Kubernetes and LINSTOR."
+  echo "Start function to delete diskful resources from node ${NODE_FOR_EVICT}"
   linstor_delete_resources_from_node "${DISKFUL_RESOURCES_TO_EVICT_NEW[@]}"
-  linstor_delete_resources_from_node "${DISKLESS_RESOURCES_TO_EVICT_NEW[@]}"
+
+  if [[ -n $DISKLESS_RESOURCES_TO_EVICT_NEW ]]; then
+    echo "Start function to delete diskless resources from node ${NODE_FOR_EVICT}"
+    linstor_delete_resources_from_node "${DISKLESS_RESOURCES_TO_EVICT_NEW[@]}"
+  fi
 fi
 
 echo "State of all resources after evacuate resources from node ${NODE_FOR_EVICT}:"

--- a/images/sds-replicated-volume-controller/tools/evict.sh
+++ b/images/sds-replicated-volume-controller/tools/evict.sh
@@ -799,6 +799,10 @@ exit_function(){
       echo "Performing uncordon on node ${NODE_FOR_EVICT}"
       execute_command "kubectl uncordon ${NODE_FOR_EVICT}"
     fi
+    if [[ -n ${SDS_REPLICATED_VOLUME_CONTROLLER_CURRENT_REPLICAS} ]]; then
+      echo "Scaling up sds-replicated-volume-controller to ${SDS_REPLICATED_VOLUME_CONTROLLER_CURRENT_REPLICAS}"
+      execute_command "kubectl -n ${LINSTOR_NAMESPACE} scale deployment sds-replicated-volume-controller --replicas=${SDS_REPLICATED_VOLUME_CONTROLLER_CURRENT_REPLICAS}"
+    fi
     echo "Terminating the script"
     exit 0
   fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR improves the `evict.sh` script by improving logging and incorporating scaling operations for the `sds-replicated-volume-controller`. Specifically, the controller is scaled down to 0 replicas after performing a database backup at the beginning of the script and scaled back up to its previous replica count at the end. Additionally, before deleting resources, the script now outputs the full list of resources to be deleted and requests confirmation.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Scaling down the `sds-replicated-volume-controller` prevents it from interfering with the eviction process by creating tie breakers. This ensures that the eviction logic within the script can operate without conflicts, maintaining the integrity and correctness of the resource eviction process. The improved logging and confirmation step provide better traceability and prevent accidental deletions.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- The `sds-replicated-volume-controller` is scaled down to 0 replicas during the eviction process and scaled back up to its original state afterward.
- Prevention of tie breaker creation by the controller during resource eviction.
- Users are prompted for confirmation before resource deletion, ensuring deliberate actions.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
