### PR TITLE
[docs] Fix check module installed status

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ EOF
 - Wait for it to become `Ready`. At this stage, you do NOT need to check the pods in the `d8-sds-node-configurator` namespace.
 
 ```shell
-kubectl get mc sds-node-configurator -w
+kubectl get module sds-node-configurator -w
 ```
 
 - Enable the `sds-replicated-volume` module. Refer to the [configuration](./configuration.html) to learn more about module settings. In the example below, the module is launched with the default settings. This will result in the following actions across all cluster nodes:
@@ -71,7 +71,7 @@ EOF
 - Wait for the module to become `Ready`.
 
 ```shell
-kubectl get mc sds-replicated-volume -w
+kubectl get module sds-replicated-volume -w
 ```
 
 - Make sure that all pods in `d8-sds-replicated-volume` and `d8-sds-node-configurator` namespaces are `Running` or `Completed` and are running on all nodes where `DRBD` resources are intended to be used.

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -48,7 +48,7 @@ EOF
 - Дождаться, когда модуль перейдет в состояние `Ready`. На этом этапе НЕ нужно проверять поды в namespace `d8-sds-node-configurator`.
 
 ```shell
-kubectl get mc sds-node-configurator -w
+kubectl get module sds-node-configurator -w
 ```
 
 - Включить модуль `sds-replicated-volume`. Возможные настройки модуля рекомендуем посмотреть в [конфигурации](./configuration.html). В примере ниже модуль запускается с настройками по умолчанию. Это приведет к тому, что на всех узлах кластера будет:
@@ -71,7 +71,7 @@ EOF
 - Дождаться, когда модуль перейдет в состояние `Ready`.
 
 ```shell
-kubectl get mc sds-replicated-volume -w
+kubectl get module sds-replicated-volume -w
 ```
 
 - Проверить, что в namespace `d8-sds-replicated-volume` и `d8-sds-node-configurator` все поды в состоянии `Running` или `Completed` и запущены на всех узлах, где планируется использовать ресурсы `DRBD`.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
In [docs](https://deckhouse.io/modules/sds-replicated-volume/stable/#enabling-modules) `kubectl get mc` dont have `Ready` status, maybe need to `kubectl get module`
