### PR TITLE
[monitoring] Change linstor satellite metrics port

### DIFF
--- a/templates/linstor-node/configmap-linstor-node-monitoring.yaml
+++ b/templates/linstor-node/configmap-linstor-node-monitoring.yaml
@@ -9,5 +9,5 @@ data:
   prometheus.toml: |2
 
     [[prometheus]]
-    address = "127.0.0.1:9942"
+    address = "127.0.0.1:4215"
     enums = true

--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -176,7 +176,7 @@ spec:
           - mountPath: /etc/linstor/client
             name: linstor-client
       - args:
-          - --secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9942
+          - --secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4215
           - --v=2
           - --logtostderr=true
           - --stale-cache-interval=1h30m
@@ -189,7 +189,7 @@ spec:
           - name: KUBE_RBAC_PROXY_CONFIG
             value: |
               upstreams:
-              - upstream: http://127.0.0.1:9942
+              - upstream: http://127.0.0.1:4215
                 path: /
                 authorization:
                   resourceAttributes:
@@ -218,15 +218,15 @@ spec:
           httpGet:
             host: 127.0.0.1
             path: /
-            port: 9942
+            port: 4215
             scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: drbd-prometheus-exporter
         ports:
-          - containerPort: 9942
-            hostPort: 9942
+          - containerPort: 4215
+            hostPort: 4215
             name: prometheus
             protocol: TCP
         resources:

--- a/templates/linstor-node/podmonitor.yaml
+++ b/templates/linstor-node/podmonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list $ (dict "prometheus" "main")) | nindent 2 }}
 spec:
   podMetricsEndpoints:
-  - targetPort: 9942
+  - targetPort: 4215
     scheme: https
     path: /metrics
     bearerTokenSecret:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change linstor satellite metrics port

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to move used hostNetwork ports to 4200-4299 TCP range

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
