### PR TITLE
[controller] Fix csi migration hook

### DIFF
--- a/hooks/migrate_csi_endpoint.sh
+++ b/hooks/migrate_csi_endpoint.sh
@@ -50,7 +50,6 @@ run_trigger() {
   if [[ -z "$sc_list" && -z "$pv_pvc_list" && -z "$pvc_list_before_migrate" && -z "$volume_snapshot_classes" && -z "$volume_snapshot_contents" ]]; then
     echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed"
     values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
-    kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}
     exit 0
   fi
   
@@ -71,7 +70,7 @@ run_trigger() {
 
   export AFFECTED_PVS_HASH=""
   export pv_pvc_list=$pv_pvc_list
-  migrate_pvc_pv
+  migrate_pv_pvc
 
   export volume_snapshot_classes=$volume_snapshot_classes
   migrate_volume_snapshot_classes
@@ -85,7 +84,6 @@ run_trigger() {
 
   delete_old_volume_attachments
 
-
   for node in $nodes_with_volumes; do
     echo "Add label ${LABEL_KEY}=${LABEL_VALUE} to node $node"
     kubectl label node $node ${LABEL_KEY}=${LABEL_VALUE} --overwrite
@@ -97,7 +95,6 @@ run_trigger() {
     values::set sdsReplicatedVolume.internal.csiMigrationHook.affectedPVsHash "$AFFECTED_PVS_HASH"
   fi
   values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
-  kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}
 }
 
 delete_resource() {
@@ -157,7 +154,7 @@ migrate_storage_classes() {
   done
 }
 
-migrate_pvc_pv() {
+migrate_pv_pvc() {
   echo "PVs/PVCs to migrate: $pv_pvc_list"
 
   mkdir -p "${temp_dir}/pvc_pv"

--- a/hooks/migrate_csi_endpoint.sh
+++ b/hooks/migrate_csi_endpoint.sh
@@ -39,15 +39,15 @@ run_trigger() {
     exit 0
   fi
 
-  echo "Secret ${NAMESPACE}/${SECRET_NAME} does not exist. Starting csi migration"
+  echo "Secret ${NAMESPACE}/${SECRET_NAME} does not exist. Starting migration of CSI endpoint"
 
   sc_list=$(kubectl get sc -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.provisioner == $oldDriverName) | .metadata.name')
   pv_pvc_list=$(kubectl get pv -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.spec.csi.driver == $oldDriverName) | .spec.claimRef.namespace + "/" + .spec.claimRef.name + "/" + .metadata.name')
-  pvc_list_before_migrate=$(kubectl get pvc --all-namespaces -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.metadata.annotations["volume.kubernetes.io/storage-provisioner"] == $oldDriverName) | .metadata.namespace + "/" + .metadata.name')
+  pvc_list=$(kubectl get pvc --all-namespaces -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.metadata.annotations["volume.kubernetes.io/storage-provisioner"] == $oldDriverName) | .metadata.namespace + "/" + .metadata.name')
   volume_snapshot_classes=$(kubectl get volumesnapshotclasses.snapshot.storage.k8s.io -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.driver == $oldDriverName) | .metadata.name')
   volume_snapshot_contents=$(kubectl get volumesnapshotcontents.snapshot.storage.k8s.io -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.spec.driver == $oldDriverName) | .metadata.name')
 
-  if [[ -z "$sc_list" && -z "$pv_pvc_list" && -z "$pvc_list_before_migrate" && -z "$volume_snapshot_classes" && -z "$volume_snapshot_contents" ]]; then
+  if [[ -z "$sc_list" && -z "$pv_pvc_list" && -z "$pvc_list" && -z "$volume_snapshot_classes" && -z "$volume_snapshot_contents" ]]; then
     echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed"
     values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
     exit 0
@@ -94,7 +94,28 @@ run_trigger() {
     echo "Set affectedPVsHash to values"
     values::set sdsReplicatedVolume.internal.csiMigrationHook.affectedPVsHash "$AFFECTED_PVS_HASH"
   fi
+
+  sc_lis_after_migrate=$(kubectl get sc -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.provisioner == $oldDriverName) | .metadata.name')
+  pv_pvc_list_after_migrate=$(kubectl get pv -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.spec.csi.driver == $oldDriverName) | .spec.claimRef.namespace + "/" + .spec.claimRef.name + "/" + .metadata.name')
+  pvc_list_after_migrate=$(kubectl get pvc --all-namespaces -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.metadata.annotations["volume.kubernetes.io/storage-provisioner"] == $oldDriverName) | .metadata.namespace + "/" + .metadata.name')
+  volume_snapshot_classes_after_migrate=$(kubectl get volumesnapshotclasses.snapshot.storage.k8s.io -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.driver == $oldDriverName) | .metadata.name')
+  volume_snapshot_contents_after_migrate=$(kubectl get volumesnapshotcontents.snapshot.storage.k8s.io -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.spec.driver == $oldDriverName) | .metadata.name')
+
+  if [[ -n "$sc_lis_after_migrate" || -n "$pv_pvc_list_after_migrate" || -n "$pvc_list_after_migrate" || -n "$volume_snapshot_classes_after_migrate" || -n "$volume_snapshot_contents_after_migrate" ]]; then
+    
+    echo "StorageClasses after migration: $sc_lis_after_migrate"
+    echo "PVs/PVCs after migration: $pv_pvc_list_after_migrate"
+    echo "PVCs after migration: $pvc_list_after_migrate"
+    echo "VolumeSnapshotClasses after migration: $volume_snapshot_classes_after_migrate"
+    echo "VolumeSnapshotContents after migration: $volume_snapshot_contents_after_migrate"
+    echo "Migration failed. There are resources that were not migrated. Fail the hook to restart the migration process"
+
+    values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "false"
+    exit 1
+  fi
+
   values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
+  exit 0
 }
 
 delete_resource() {

--- a/hooks/migrate_csi_endpoint_check.sh
+++ b/hooks/migrate_csi_endpoint_check.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /deckhouse/shell_lib.sh
+
+get_config() {
+  echo '{"configVersion":"v1", "afterHelm": 10}'
+}
+
+run_trigger() {
+  export OLD_DRIVER_NAME="linstor.csi.linbit.com"
+  export NEW_DRIVER_NAME="replicated.csi.storage.deckhouse.io"
+  export SECRET_NAME="csi-migration-completed"
+  export NAMESPACE="d8-sds-replicated-volume"
+  export TIMESTAMP="$(date +"%Y%m%d%H%M%S")"
+  echo "Check csi migration shell hook started"
+
+  if kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" > /dev/null 2>&1; then
+    echo "Secret ${NAMESPACE}/${SECRET_NAME} exists. Migration has been finished before. No need to check csi migration"
+    values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
+    exit 0
+  fi
+
+  echo "Secret ${NAMESPACE}/${SECRET_NAME} does not exist. Checking csi migration"
+
+  sc_list=$(kubectl get sc -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.provisioner == $oldDriverName) | .metadata.name')
+  pv_pvc_list=$(kubectl get pv -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.spec.csi.driver == $oldDriverName) | .spec.claimRef.namespace + "/" + .spec.claimRef.name + "/" + .metadata.name')
+  pvc_list=$(kubectl get pvc --all-namespaces -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.metadata.annotations["volume.kubernetes.io/storage-provisioner"] == $oldDriverName) | .metadata.namespace + "/" + .metadata.name')
+  volume_snapshot_classes=$(kubectl get volumesnapshotclasses.snapshot.storage.k8s.io -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.driver == $oldDriverName) | .metadata.name')
+  volume_snapshot_contents=$(kubectl get volumesnapshotcontents.snapshot.storage.k8s.io -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.spec.driver == $oldDriverName) | .metadata.name')
+
+  if [[ -z "$sc_list" && -z "$pv_pvc_list" && -z "$pvc_list" && -z "$volume_snapshot_classes" && -z "$volume_snapshot_contents" ]]; then
+    echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed"
+    values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
+    kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}
+    exit 0
+  fi
+  
+  echo "StorageClasses: $sc_list"
+  echo "PVs/PVCs: $pv_pvc_list"
+  echo "PVCs: $pvc_list"
+  echo "VolumeSnapshotClasses: $volume_snapshot_classes"
+  echo "VolumeSnapshotContents: $volume_snapshot_contents"
+  echo "There are resources to migrate. Fail the hook to restart the migration process"
+  values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "false"
+
+  exit 1
+}
+
+
+if [[ ${1-} == "--config" ]] ; then
+  get_config
+else
+  run_trigger
+fi

--- a/hooks/migrate_csi_endpoint_check.sh
+++ b/hooks/migrate_csi_endpoint_check.sh
@@ -46,7 +46,7 @@ run_trigger() {
     echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed"
     values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
     kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}
-    kubectl -n ${NAMESPACE} label secret ${SECRET_NAME} heritage=deckhouse,module=sds-replicated-volume
+    kubectl -n ${NAMESPACE} label secret ${SECRET_NAME} heritage=deckhouse module=sds-replicated-volume
     exit 0
   fi
   

--- a/hooks/migrate_csi_endpoint_check.sh
+++ b/hooks/migrate_csi_endpoint_check.sh
@@ -45,7 +45,7 @@ run_trigger() {
   if [[ -z "$sc_list" && -z "$pv_pvc_list" && -z "$pvc_list" && -z "$volume_snapshot_classes" && -z "$volume_snapshot_contents" ]]; then
     echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed"
     values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
-    kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}
+    kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME} -l heritage=deckhouse,module=sds-replicated-volume
     exit 0
   fi
   
@@ -55,7 +55,7 @@ run_trigger() {
   echo "VolumeSnapshotClasses: $volume_snapshot_classes"
   echo "VolumeSnapshotContents: $volume_snapshot_contents"
   echo "There are resources to migrate. Fail the hook to restart the migration process"
-  
+
   values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "false"
   exit 1
 }

--- a/hooks/migrate_csi_endpoint_check.sh
+++ b/hooks/migrate_csi_endpoint_check.sh
@@ -43,7 +43,7 @@ run_trigger() {
   volume_snapshot_contents=$(kubectl get volumesnapshotcontents.snapshot.storage.k8s.io -o json | jq -r --arg oldDriverName "$OLD_DRIVER_NAME" '.items[] | select(.spec.driver == $oldDriverName) | .metadata.name')
 
   if [[ -z "$sc_list" && -z "$pv_pvc_list" && -z "$pvc_list" && -z "$volume_snapshot_classes" && -z "$volume_snapshot_contents" ]]; then
-    echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed"
+    echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed."
     values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
     kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}
     kubectl -n ${NAMESPACE} label secret ${SECRET_NAME} heritage=deckhouse module=sds-replicated-volume

--- a/hooks/migrate_csi_endpoint_check.sh
+++ b/hooks/migrate_csi_endpoint_check.sh
@@ -45,7 +45,8 @@ run_trigger() {
   if [[ -z "$sc_list" && -z "$pv_pvc_list" && -z "$pvc_list" && -z "$volume_snapshot_classes" && -z "$volume_snapshot_contents" ]]; then
     echo "No StorageClasses, PVCs, PVs, VolumeSnapshotClasses, VolumeSnapshotContents to migrate. Migration not needed"
     values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
-    kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME} -l heritage=deckhouse,module=sds-replicated-volume
+    kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}
+    kubectl -n ${NAMESPACE} label secret ${SECRET_NAME} heritage=deckhouse,module=sds-replicated-volume
     exit 0
   fi
   

--- a/hooks/migrate_csi_endpoint_check.sh
+++ b/hooks/migrate_csi_endpoint_check.sh
@@ -55,8 +55,8 @@ run_trigger() {
   echo "VolumeSnapshotClasses: $volume_snapshot_classes"
   echo "VolumeSnapshotContents: $volume_snapshot_contents"
   echo "There are resources to migrate. Fail the hook to restart the migration process"
+  
   values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "false"
-
   exit 1
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR fixes the migration hook responsible for transitioning from `linstor.csi.linbit.com` CSI provisioner name to `replicated.csi.storage.deckhouse.io`. Initially, the hook attempted to create a `csi-migration-completed` secret upon successful migration. However, if the namespace for the module was not yet created (since the hook runs `beforeHelm`), the hook would fail. The creation of the secret has now been moved to a separate hook that runs `afterHelm`, checking if the migration was successful before creating the secret.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The previous implementation could fail if the namespace did not exist when the `beforeHelm` hook was executed. By moving the secret creation to an `afterHelm` hook, we ensure that the namespace is present, thus preventing the hook from failing and ensuring a smooth migration process.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Moved the creation of the `csi-migration-completed` secret from the `beforeHelm` hook to an `afterHelm` hook.
- The `afterHelm` hook checks if the migration was successful and then creates the secret.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
