### PR TITLE
[controller] Fix enableThinProvisioning value patch

### DIFF
--- a/images/webhooks/src/handlers/rspValidator.go
+++ b/images/webhooks/src/handlers/rspValidator.go
@@ -141,6 +141,7 @@ func RSPValidate(ctx context.Context, _ *model.AdmissionReview, obj metav1.Objec
 				klog.Info("Enabling thin pools support")
 				patchBytes, err := json.Marshal(map[string]interface{}{
 					"spec": map[string]interface{}{
+						"version": 1,
 						"settings": map[string]interface{}{
 							"enableThinProvisioning": true,
 						},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix enableThinProvisioning value patch

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

No problem in webhook

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
