### PR TITLE
[controller] Improve migration hook with checks for existence of PVCs and terminating PVs

### DIFF
--- a/hooks/migrate_csi_endpoint.sh
+++ b/hooks/migrate_csi_endpoint.sh
@@ -193,9 +193,6 @@ migrate_pv_pvc() {
       pvc=${array[1]}
       pv=${array[2]}
 
-      
-
-
       if kubectl get pvc "$pvc" -n "$namespace" -o yaml > "pvc-${pvc}.yaml" 2>/dev/null; then
         echo "PVC $pvc retrieved successfully and saved to pvc-${pvc}.yaml."
         cp pvc-${pvc}.yaml old.pvc-${pvc}.yaml.$TIMESTAMP

--- a/hooks/migrate_csi_endpoint.sh
+++ b/hooks/migrate_csi_endpoint.sh
@@ -193,12 +193,18 @@ migrate_pv_pvc() {
       pvc=${array[1]}
       pv=${array[2]}
 
-      kubectl get pvc $pvc -n $namespace -o yaml > pvc-${pvc}.yaml
+      
+
+
+      if kubectl get pvc "$pvc" -n "$namespace" -o yaml > "pvc-${pvc}.yaml" 2>/dev/null; then
+        echo "PVC $pvc retrieved successfully and saved to pvc-${pvc}.yaml."
+        cp pvc-${pvc}.yaml old.pvc-${pvc}.yaml.$TIMESTAMP
+      else
+        echo "PVC $pvc does not exist or couldn't be retrieved."
+      fi
+
       kubectl get pv $pv -o yaml > pv-${pv}.yaml
-
-      cp pvc-${pvc}.yaml old.pvc-${pvc}.yaml.$TIMESTAMP
       cp pv-${pv}.yaml old.pv-${pv}.yaml.$TIMESTAMP
-
       sed -i "s/$escaped_OLD_DRIVER_NAME/$NEW_DRIVER_NAME/g" pv-${pv}.yaml
       sed -i "s/$OLD_ATTACHER/$NEW_ATTACHER/g" pv-${pv}.yaml
       sed -i '/resourceVersion: /d' pv-${pv}.yaml
@@ -217,17 +223,34 @@ migrate_pv_pvc() {
       namespace=${array[0]}
       pvc=${array[1]}
       pv=${array[2]}
+
+      echo "Checking if PVC $pvc exists in namespace $namespace"
+      if kubectl get pvc "$pvc" -n "$namespace" &>/dev/null; then
+        echo "PVC $pvc exists in namespace $namespace"
+        pvc_exists=true
+      else
+        echo "PVC $pvc does not exist in namespace $namespace. Skipping migration of PVC $pvc."
+        pvc_exists=false
+      fi
+
       echo "Deleting pv: $pv"
       kubectl delete pv $pv --wait=false # the pv will stuck in Terminating state
       echo "Deleting finalizer from pv: $pv"
       kubectl patch pv $pv --type json -p '[{"op": "remove", "path": "/metadata/finalizers"}]'
-      echo "Patching annotations in pvc: $pvc"
-      kubectl patch pvc ${pvc} -n $namespace  --type=json -p='[{"op": "replace", "path": "/metadata/annotations/volume.beta.kubernetes.io~1storage-provisioner", "value":"'$NEW_DRIVER_NAME'"}]'
-      kubectl patch pvc ${pvc} -n $namespace  --type=json -p='[{"op": "replace", "path": "/metadata/annotations/volume.kubernetes.io~1storage-provisioner", "value":"'$NEW_DRIVER_NAME'"}]'
+      
+      if [[ "$pvc_exists" == "true" ]]; then
+        echo "Patching annotations in pvc: $pvc"
+        kubectl patch pvc ${pvc} -n $namespace  --type=json -p='[{"op": "replace", "path": "/metadata/annotations/volume.beta.kubernetes.io~1storage-provisioner", "value":"'$NEW_DRIVER_NAME'"}]'
+        kubectl patch pvc ${pvc} -n $namespace  --type=json -p='[{"op": "replace", "path": "/metadata/annotations/volume.kubernetes.io~1storage-provisioner", "value":"'$NEW_DRIVER_NAME'"}]'
+      fi
+
       echo "Recreating pv: $pv"
       kubectl create -f pv-${pv}.yaml
-      echo "Deleting annotation from pvc $pvc to trigger pvc/pv binding"
-      kubectl patch pvc ${pvc} -n $namespace --type=json -p='[{"op": "remove", "path": "/metadata/annotations/pv.kubernetes.io~1bind-completed"}]'
+
+      if [[ "$pvc_exists" == "true" ]]; then
+        echo "Deleting annotation from pvc $pvc to trigger pvc/pv binding"
+        kubectl patch pvc ${pvc} -n $namespace --type=json -p='[{"op": "remove", "path": "/metadata/annotations/pv.kubernetes.io~1bind-completed"}]'
+      fi
 
       IFS=$old_ifs
     done


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR enhances the migration hook by adding two checks:
1. **PVC Existence Check**: Before performing migration operations, the hook now verifies the existence of a corresponding PVC for each PV. Previously, if a PV existed without a PVC (e.g., when `RECLAIMPOLICY=retain`), the hook would fail. This update ensures that operations are skipped when the PVC is absent, preventing errors.
2. **Terminating PV Check**: The hook now checks for PVs in a terminating state with the migrating provisioner. If such PVs are found, the hook will terminate with an error, avoiding potential issues.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The previous implementation could fail in scenarios where a PV existed without a PVC, especially when `RECLAIMPOLICY=retain` was set. Moreover, handling terminating PVs was insufficient, leading to possible migration errors. These enhancements make the migration process more reliable by addressing these edge cases.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- The migration hook correctly handles situations where PVs exist without corresponding PVCs, reducing errors.
- It also identifies and manages PVs in a terminating state, ensuring a smooth migration process.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
