### PR TITLE
[controller] Add resource CSIDriver with new provisioner, remove resource CSIDriver with old provisioner, and implement additional kubelet restart

### DIFF
--- a/hooks/migrate_csi_endpoint.sh
+++ b/hooks/migrate_csi_endpoint.sh
@@ -122,6 +122,12 @@ run_trigger() {
     exit 1
   fi
 
+  if kubectl delete csidriver ${OLD_DRIVER_NAME} > /dev/null 2>&1; then
+    echo "CSIDriver ${OLD_DRIVER_NAME} deleted"
+  else
+    echo "CSIDriver ${OLD_DRIVER_NAME} does not exist. Skipping deletion"
+  fi
+
   values::set sdsReplicatedVolume.internal.csiMigrationHook.completed "true"
   exit 0
 }

--- a/templates/linstor-csi/csidriver.yaml
+++ b/templates/linstor-csi/csidriver.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: replicated.csi.storage.deckhouse.io
+spec:
+  attachRequired: true
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  podInfoOnMount: true
+  requiresRepublish: false
+  seLinuxMount: true
+  storageCapacity: true
+  volumeLifecycleModes:
+    - Persistent

--- a/templates/nodegroupconfiguration-restart-kubelet.yaml
+++ b/templates/nodegroupconfiguration-restart-kubelet.yaml
@@ -38,6 +38,13 @@ spec:
     if [ "$is_kubelet_restart_needed" = "true" ]; then
       echo "Kubelet restart is needed. Restarting kubelet."
       systemctl restart kubelet
+
+      echo "Sleeping for 180 seconds before restarting kubelet again."
+      sleep 180
+
+      echo "Restarting kubelet again."
+      systemctl restart kubelet
+
       bb-kubectl --kubeconfig $kubeconfig label node "$(hostname -s)" "$LABEL_KEY"-
     else
       echo "Kubelet restart is not needed. Exiting."


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR introduces several important updates:
1. **New CSI Driver Provisioner**: Added the creation of a CSI driver resource with the new provisioner.
2. **Remove Old CSI Driver**: Implemented the removal of the CSI driver resource associated with the old provisioner.
3. **Additional Kubelet Restart**: Added a second restart of the kubelet 180 seconds after the first. This additional restart addresses an issue where some pods, particularly those using PVCs with the migrating provisioner, would get stuck in a `Terminating` state due to unmount errors if only one restart was performed.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Successful creation of the new CSI driver resource.
- Complete removal of the old CSI driver resource.
- Elimination of issues with pods getting stuck in `Terminating` state due to unmount errors, thanks to the additional kubelet restart.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
