### PR TITLE
[bashible] remove deprecated registryScheme parameter

### DIFF
--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -1,9 +1,8 @@
 type: object
 properties:
-  # TODO: Set the option below to deprecated when the PR https://github.com/deckhouse/deckhouse/pull/7263 will reach RockSolid channel
   registryScheme:
     type: string
-    description: Change this parameter to "http" if the module registry does not support TLS.
+    description: Deprecated parameter. Remove it from ModuleConfig for Deckhouse with version greater than 1.57.
     default: https
   logLevel:
     type: string

--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -45,7 +45,11 @@ spec:
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
     MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsReplicatedVolume.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
+    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
+    MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registry.scheme }}"
+    {{- else }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registryScheme }}"
+    {{- end }}
     MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsReplicatedVolume.registry.base }} | cut -f 1 -d '/')
     MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsReplicatedVolume.registry.base }} | cut -f 2- -d '/')"/sds-replicated-volume"
     MODULE_REPOSITORY="{{ .Values.sdsReplicatedVolume.registry.base }}"

--- a/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -45,7 +45,11 @@ spec:
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
     MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsReplicatedVolume.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
+    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
+    MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registry.scheme }}"
+    {{- else }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registryScheme }}"
+    {{- end }}
     MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsReplicatedVolume.registry.base }} | cut -f 1 -d '/')
     MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsReplicatedVolume.registry.base }} | cut -f 2- -d '/')"/sds-replicated-volume"
     MODULE_REPOSITORY="{{ .Values.sdsReplicatedVolume.registry.base }}"

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -45,7 +45,11 @@ spec:
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
     MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsReplicatedVolume.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
+    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
+    MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registry.scheme }}"
+    {{- else }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registryScheme }}"
+    {{- end }}
     MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsReplicatedVolume.registry.base }} | cut -f 1 -d '/')
     MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsReplicatedVolume.registry.base }} | cut -f 2- -d '/')"/sds-replicated-volume"
     MODULE_REPOSITORY="{{ .Values.sdsReplicatedVolume.registry.base }}"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove deprecated registryScheme parameter

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct work with registry from ModuleSource resource without external workarounds

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
