### PR TITLE
[controller] Fix a bug with wrong not found error lib

### DIFF
--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_pool.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_pool.go
@@ -246,7 +246,7 @@ func ReconcileReplicatedStoragePool(ctx context.Context, cl client.Client, lc *l
 
 		existedStoragePool, err := lc.Nodes.GetStoragePool(ctx, nodeName, replicatedSP.Name)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if err == lapi.NotFoundError {
 				log.Info(fmt.Sprintf("[ReconcileReplicatedStoragePool] Storage Pool %s on node %s on vg %s was not found. Creating it", replicatedSP.Name, nodeName, lvmVgForLinstor))
 				createErr := lc.Nodes.CreateStoragePool(ctx, nodeName, newStoragePool)
 				if createErr != nil {


### PR DESCRIPTION
## Description
Fixed a bug when Linstor API's not found error type was handled by kubernetes api errors lib.

## Why do we need it, and what problem does it solve?
Correct linstor not found error handling.

## What is the expected result?
Correct linstor not found error handling.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
