### PR TITLE
[controller] Honor `AutoplaceTarget` property in `evict.sh` script

### DIFF
--- a/images/service-scripts/tools/evict.sh
+++ b/images/service-scripts/tools/evict.sh
@@ -422,7 +422,7 @@ linstor_change_replicas_count() {
     sleep 2
     if (( ${current_diskful_replicas_count} < ${desired_diskful_replicas_count} )); then
       difference=$((desired_diskful_replicas_count - current_diskful_replicas_count))
-      eval "$(get_sorted_free_nodes "$RESOURCE_NODES" "$ALL_STORAGE_POOLS_NODES" "${diskful_storage_pool_name}")"
+      eval "$(get_sorted_free_nodes "$RESOURCE_NODES" "$FILTERED_STORAGE_POOLS_NODES" "${diskful_storage_pool_name}")"
 
       echo "The total number of diskfull replicas for resource ${resource_name} (${current_diskful_replicas_count}) less then the desired number of replicas(${desired_diskful_replicas_count}). Adding ${difference} diskfull replicas for this resource"
       for ((i=0; i<difference; i++)); do
@@ -432,7 +432,7 @@ linstor_change_replicas_count() {
           echo "i=${i}"
           echo free nodes count=${#sorted_free_nodes[@]}
           echo RESOURCE_NODES=${RESOURCE_NODES}
-          echo ALL_STORAGE_POOLS_NODES=${ALL_STORAGE_POOLS_NODES}
+          echo FILTERED_STORAGE_POOLS_NODES=${FILTERED_STORAGE_POOLS_NODES}
           echo diskful_storage_pool_name=${diskful_storage_pool_name}
           exit_function
           break
@@ -455,7 +455,7 @@ linstor_change_replicas_count() {
         echo "Creating new replica on node \"${node_name_for_new_replica}\" for resource \"${resource_name}\""
         exec_linstor_with_exit_code_check resource create ${node_name_for_new_replica} ${resource_name} --storage-pool ${diskful_storage_pool_name}
         
-        ALL_STORAGE_POOLS_NODES=$(echo $ALL_STORAGE_POOLS_NODES | jq --arg node_name "${node_name_for_new_replica}" --arg diskfulStoragePoolName "${diskful_storage_pool_name}" --argjson resource_allocated_size_kib "${resource_allocated_size_kib}" '
+        FILTERED_STORAGE_POOLS_NODES=$(echo $FILTERED_STORAGE_POOLS_NODES | jq --arg node_name "${node_name_for_new_replica}" --arg diskfulStoragePoolName "${diskful_storage_pool_name}" --argjson resource_allocated_size_kib "${resource_allocated_size_kib}" '
           map(if .node_name == $node_name and .storage_pool_name == $diskfulStoragePoolName then .free_capacity -= $resource_allocated_size_kib else . end)
         ')
 
@@ -523,13 +523,13 @@ linstor_change_replicas_count() {
 
 get_sorted_free_nodes() {
   local resource_nodes=$1
-  local all_storage_pools_nodes=$2
+  local filtered_storage_pools_nodes=$2
   local storage_pool_name=$3
 
   resource_all_nodes=($(echo $resource_nodes | jq -r '.[].node_name'))
   # resource_diskful_nodes=($(echo $resource_nodes | jq -r --arg disklessStorPoolName "${DISKLESS_STORAGE_POOL}" '.[] | select(.storage_pool != $disklessStorPoolName) | .node_name'))
-  nodes_for_storage_pool=($(echo $all_storage_pools_nodes | jq -r --arg storagePoolName "${storage_pool_name}" '.[] | select(.storage_pool_name == $storagePoolName) | .node_name'))
-  free_capacities=($(echo $all_storage_pools_nodes | jq -r --arg storagePoolName "${storage_pool_name}" '.[] | select(.storage_pool_name == $storagePoolName) | .free_capacity'))
+  nodes_for_storage_pool=($(echo $filtered_storage_pools_nodes | jq -r --arg storagePoolName "${storage_pool_name}" '.[] | select(.storage_pool_name == $storagePoolName) | .node_name'))
+  free_capacities=($(echo $filtered_storage_pools_nodes | jq -r --arg storagePoolName "${storage_pool_name}" '.[] | select(.storage_pool_name == $storagePoolName) | .free_capacity'))
 
   free_nodes=()
 
@@ -550,7 +550,7 @@ get_sorted_free_nodes() {
 
 create_tiebreaker() {
   local resource_name=$1
-  local all_storage_pools_nodes=$2
+  local filtered_storage_pools_nodes=$2
 
   while true; do
     count=0
@@ -604,7 +604,7 @@ create_tiebreaker() {
   if (( ${diskless_replicas_count} < 1 && ${diskful_replicas_count} == 2)); then
     echo "The count of diskless replicas is ${diskless_replicas_count} and count of diskful replicas is ${diskful_replicas_count}. Creating a TieBreaker for resource ${resource_name}"
 
-    eval "$(get_sorted_free_nodes "$RESOURCE_NODES" "$ALL_STORAGE_POOLS_NODES" "${DISKLESS_STORAGE_POOL}")"
+    eval "$(get_sorted_free_nodes "$RESOURCE_NODES" "$FILTERED_STORAGE_POOLS_NODES" "${DISKLESS_STORAGE_POOL}")"
     free_node_count=${#sorted_free_nodes[@]}
     if [ 0 -ge ${free_node_count} ]; then
       echo "Error: Not enough free nodes for create tiebreaker"
@@ -1207,7 +1207,19 @@ exec_linstor_with_exit_code_check node set-property ${NODE_FOR_EVICT} AutoplaceT
 
 RESOURCE_AND_GROUP_NAMES=$(linstor -m --output-version=v1 resource-definition list -r ${DISKFUL_RESOURCES_TO_EVICT} | jq -r '.[][] | {resource: .name, resource_group: .resource_group_name}')
 RESOURCE_GROUPS=$(linstor -m --output-version=v1 resource-group list | jq -r '.[][] | {resource_group: .name, place_count: .select_filter.place_count}')
+
 ALL_STORAGE_POOLS_NODES=$(linstor -m --output-version=v1 storage-pool list | jq  '[.[][] | {storage_pool_name: .storage_pool_name, node_name: .node_name, free_capacity: .free_capacity}]')
+UNSUITABLE_NODES=$(linstor -m --output-version=v1 node list | jq -r '[.[][] | select(.props.AutoplaceTarget == "false") | .name]')
+UNSUITABLE_NODES_ARRAY=($(echo $UNSUITABLE_NODES | jq -r '.[]'))
+FILTERED_STORAGE_POOLS_NODES=$(echo $ALL_STORAGE_POOLS_NODES | jq --argjson unsuitable_nodes "$(echo $UNSUITABLE_NODES)" '
+    . | map(select(.node_name as $node_name | $unsuitable_nodes | index($node_name) | not))
+')
+
+for UNSUITABLE_NODE in "${UNSUITABLE_NODES_ARRAY[@]}"; do
+  echo "Node ${UNSUITABLE_NODE} is excluded from the LINSTOR scheduler. So the resources will not be placed on this node."
+done
+echo "List of nodes and storage pools available for placement: FILTERED_STORAGE_POOLS_NODES=${FILTERED_STORAGE_POOLS_NODES}"
+
 
 echo "List of resources to be evicted from node ${NODE_FOR_EVICT}:"
 exec_linstor_with_exit_code_check resource list-volumes -r ${DISKFUL_RESOURCES_TO_EVICT}

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -12,6 +12,7 @@ git:
     includePaths:
     - scripts
     - tools
+    before: setup
 
 shell:
   setup:
@@ -32,7 +33,7 @@ import:
       - replicas_manager.sh
       - install
       - uninstall
-    after: setup
+    before: setup
 docker:
   LABEL:
     distro: all

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -9,9 +9,6 @@ final: false
 git:
   - add: /images/{{ $.ImageName }}
     to: /
-    includePaths:
-    - scripts
-    - tools
 
 shell:
   setup:

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -9,9 +9,8 @@ final: false
 git:
   - add: /images/{{ $.ImageName }}
     to: /
-    includePaths:
-    - scripts
-    - tools
+    excludePaths:
+    - werf.inc.yaml
 
 shell:
   setup:

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -12,7 +12,6 @@ git:
     includePaths:
     - scripts
     - tools
-    before: setup
 
 shell:
   setup:
@@ -29,7 +28,7 @@ import:
     add: /
     to: /
     includePaths:
-      - evict.sh
+      # - evict.sh
       - replicas_manager.sh
       - install
       - uninstall

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -32,7 +32,7 @@ import:
       - replicas_manager.sh
       - install
       - uninstall
-    before: setup
+    after: setup
 docker:
   LABEL:
     distro: all

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -9,6 +9,9 @@ final: false
 git:
   - add: /images/{{ $.ImageName }}
     to: /
+    includePaths:
+    - scripts
+    - tools
 
 shell:
   setup:

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -28,7 +28,7 @@ import:
     add: /
     to: /
     includePaths:
-      # - evict.sh
+      - evict.sh
       - replicas_manager.sh
       - install
       - uninstall

--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -90,6 +90,7 @@ spec:
     # DRBD requires the kernel sources to be installed.
     # Install actual kernel headers. It can be different from current kernel version!
     # So further we check, if we need new kernel version. It is altlinux feature.
+    apt-get update
     apt-get -y install kernel-headers-modules-std-def
 
     if [ ! -e "/lib/modules/$kernel_version_in_use/build" ]; then


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR modifies the `evict.sh` script to respect the `AutoplaceTarget` property. When this property is set to `false`, the script will ensure that resource replicas do not move to such nodes during evacuation. This prevents automatic placement of replicas on nodes that are not intended to host them.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Without this change, replicas could be placed on nodes with `AutoplaceTarget=false`, leading to undesired resource placement. Respecting the `AutoplaceTarget` setting improves control over resource allocation, ensuring that replicas are only moved to appropriate nodes.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Replicas will not be placed on nodes with the `AutoplaceTarget=false` setting during eviction.
- Improved control over where resources are placed during evacuation processes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
