### PR TITLE
[scheduler] Fix admission controller secret conflict

### DIFF
--- a/hooks/generate_webhook_certs.py
+++ b/hooks/generate_webhook_certs.py
@@ -20,9 +20,10 @@ from lib.module import values as module_values
 from deckhouse import hook
 from typing import Callable
 import common
+import os
 
-def main(ctx: hook.Context):
-    print(ctx)
+def main():
+    print(os.environ['CONFIG_VALUES_PATH'])
     common_secrets = (
         TlsSecret(
             cn="webhooks",
@@ -37,10 +38,10 @@ def main(ctx: hook.Context):
             ),
     )
 
-    d8_version = module_values.get_value("global.deckhouseVersion", ctx.values)
-    print(f"d8_version={d8_version}")
+    # d8_version = module_values.get_value("global.deckhouseVersion", ctx.values)
+    # print(f"d8_version={d8_version}")
 
-    if d8_version:
+    if 1:
         tls_secrets = (*common_secrets,
             TlsSecret(
                 cn="linstor-scheduler-admission",

--- a/hooks/generate_webhook_certs.py
+++ b/hooks/generate_webhook_certs.py
@@ -20,11 +20,18 @@ from lib.module import values as module_values
 from deckhouse import hook
 from typing import Callable
 import common
-import os
 
 def main():
-    print(os.environ['CONFIG_VALUES_PATH'])
-    common_secrets = (
+    hook = GenerateCertificateHook(
+        TlsSecret(
+            cn="linstor-scheduler-admission",
+            name="linstor-scheduler-admission-certs",
+            sansGenerator=default_sans([
+                "linstor-scheduler-admission",
+                f"linstor-scheduler-admission.{common.NAMESPACE}",
+                f"linstor-scheduler-admission.{common.NAMESPACE}.svc"]),
+            values_path_prefix=f"{common.MODULE_NAME}.internal.webhookCert"
+            ),
         TlsSecret(
             cn="webhooks",
             name="webhooks-https-certs",
@@ -36,28 +43,6 @@ def main():
                 ]),
             values_path_prefix=f"{common.MODULE_NAME}.internal.customWebhookCert"
             ),
-    )
-
-    # d8_version = module_values.get_value("global.deckhouseVersion", ctx.values)
-    # print(f"d8_version={d8_version}")
-
-    if True:
-        tls_secrets = (*common_secrets,
-            TlsSecret(
-                cn="linstor-scheduler-admission",
-                name="linstor-scheduler-admission-certs",
-                sansGenerator=default_sans([
-                    "linstor-scheduler-admission",
-                    f"linstor-scheduler-admission.{common.NAMESPACE}",
-                    f"linstor-scheduler-admission.{common.NAMESPACE}.svc"]),
-                values_path_prefix=f"{common.MODULE_NAME}.internal.webhookCert"
-                ),
-        )
-    else:
-        tls_secrets = common_secrets
-
-    hook = GenerateCertificateHook(
-        tls_secrets,
         cn="linstor-scheduler-admission",
         common_ca=True,
         namespace=common.NAMESPACE)

--- a/hooks/generate_webhook_certs.py
+++ b/hooks/generate_webhook_certs.py
@@ -41,7 +41,7 @@ def main():
     # d8_version = module_values.get_value("global.deckhouseVersion", ctx.values)
     # print(f"d8_version={d8_version}")
 
-    if 1:
+    if True:
         tls_secrets = (*common_secrets,
             TlsSecret(
                 cn="linstor-scheduler-admission",

--- a/templates/linstor-scheduler-admission/secret.yaml
+++ b/templates/linstor-scheduler-admission/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  This secret should be removed after almost all clients moved to 1.64+ Deckhouse version.
+  This secret should be removed after almost all clients moved to 1.64+ Deckhouse version (February 2025?).
   Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following:
   requirements:
     deckhouse: >= 1.64

--- a/templates/linstor-scheduler-admission/secret.yaml
+++ b/templates/linstor-scheduler-admission/secret.yaml
@@ -1,4 +1,9 @@
-{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
+{{- /*
+  This secret should be removed after almost all clients moved to 1.64+ Deckhouse version.
+  Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following:
+  requirements:
+    deckhouse: >= 1.64
+*/ }}
 ---
 apiVersion: v1
 kind: Secret
@@ -13,4 +18,3 @@ data:
   tls.key: {{ .key }}
   ca.crt: {{ .ca }}
   {{- end }}
-{{- end }}

--- a/templates/linstor-scheduler-admission/secret.yaml
+++ b/templates/linstor-scheduler-admission/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  This secret should be removed after almost all clients moved to 1.64+ Deckhouse version (February 2025?).
+  TODO: This secret should be removed after almost all clients moved to 1.64+ Deckhouse version (February 2025?).
   Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following:
   requirements:
     deckhouse: >= 1.64

--- a/templates/linstor-scheduler-admission/secret.yaml
+++ b/templates/linstor-scheduler-admission/secret.yaml
@@ -1,7 +1,9 @@
-{{- /* This secret should be removed after almost all clients moved to 1.64+ Deckhouse version (February 2025?). */ }}
-{{- /* Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following: */ }}
-{{- /* requirements: */ }}
-{{- /*   deckhouse: >= 1.64 */ }}
+{{- /*
+  This secret should be removed after almost all clients moved to 1.64+ Deckhouse version (February 2025?).
+  Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following:
+  requirements:
+    deckhouse: >= 1.64
+*/ }}
 ---
 apiVersion: v1
 kind: Secret

--- a/templates/linstor-scheduler-admission/secret.yaml
+++ b/templates/linstor-scheduler-admission/secret.yaml
@@ -3,7 +3,7 @@
   Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following:
   requirements:
     deckhouse: >= 1.64
-*/ }}
+*/}}
 ---
 apiVersion: v1
 kind: Secret

--- a/templates/linstor-scheduler-admission/secret.yaml
+++ b/templates/linstor-scheduler-admission/secret.yaml
@@ -1,9 +1,7 @@
-{{- /*
-  This secret should be removed after almost all clients moved to 1.64+ Deckhouse version (February 2025?).
-  Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following:
-  requirements:
-    deckhouse: >= 1.64
-*/ }}
+{{- /* This secret should be removed after almost all clients moved to 1.64+ Deckhouse version (February 2025?). */ }}
+{{- /* Also remove it from hooks/generate_webhook_certs.py and set in module.yaml following: */ }}
+{{- /* requirements: */ }}
+{{- /*   deckhouse: >= 1.64 */ }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
## Description
Secret 'linstor-scheduler-admission-certs' was removed in PR #185 for Deckhouse 1.64+, but it is being recreated by `generate_webhook_certs.py` hook and then deleted by Helm and this behavior happens again and again.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fix bug described above.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Secret 'linstor-scheduler-admission-certs' should stay 'as is' until most users upgrade to Deckhouse 1.64+ (February 2025?)
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
