### PR TITLE
[controller] Add finalizers to StorageClass

### DIFF
--- a/images/sds-replicated-volume-controller/src/go.sum
+++ b/images/sds-replicated-volume-controller/src/go.sum
@@ -9,14 +9,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240805103635-969dc811217b h1:EYmHWTWcWMpyxJGZK05ZxlIFnh9s66DRrxLw/LNb/xw=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240805103635-969dc811217b/go.mod h1:H71+9G0Jr46Qs0BA3z3/xt0h9lbnJnCEYcaCJCWFBf0=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240919102704-a035b4a92e77 h1:Y3vswUk/rnCpkZzWBk+Mlr9LtMg6EI5LkQ4GvgHCslI=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240919102704-a035b4a92e77/go.mod h1:H71+9G0Jr46Qs0BA3z3/xt0h9lbnJnCEYcaCJCWFBf0=
 github.com/deckhouse/sds-node-configurator/api v0.0.0-20240925090458-249de2896583 h1:HQd5YFQqoHj/CQwBKFCyuVCQmNV0PdML8QJiyDka4fQ=
 github.com/deckhouse/sds-node-configurator/api v0.0.0-20240925090458-249de2896583/go.mod h1:H71+9G0Jr46Qs0BA3z3/xt0h9lbnJnCEYcaCJCWFBf0=
-github.com/deckhouse/sds-replicated-volume/api v0.0.0-20240812165341-a73e664454b9 h1:keKcnq6do7yxGZHeNERhhx3dH1/wQmj+x5vxcWH3CcI=
-github.com/deckhouse/sds-replicated-volume/api v0.0.0-20240812165341-a73e664454b9/go.mod h1:6yz0RtbkLVJtK2DeuvgfaqBZRl5V5ax1WsfPF5pbnvo=
 github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0 h1:C7t6eeMaEQVy6e8CarIhscYQlNmw5e3G36y7l7Y21Ao=
 github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=

--- a/images/sds-replicated-volume-controller/src/pkg/controller/controller_suite_test.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/controller_suite_test.go
@@ -18,6 +18,7 @@ package controller_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	. "github.com/LINBIT/golinstor/client"
@@ -227,6 +228,7 @@ func getAndValidateSC(ctx context.Context, cl client.Client, replicatedSC srv.Re
 	Expect(*storageClass.AllowVolumeExpansion).To(BeTrue())
 	Expect(*storageClass.VolumeBindingMode).To(Equal(volumeBindingMode))
 	Expect(*storageClass.ReclaimPolicy).To(Equal(corev1.PersistentVolumeReclaimPolicy(replicatedSC.Spec.ReclaimPolicy)))
+	Expect(slices.Contains(storageClass.ObjectMeta.Finalizers, controller.StorageClassFinalizerName)).To(BeTrue())
 
 	return storageClass
 }

--- a/images/sds-replicated-volume-controller/src/pkg/controller/controller_suite_test.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/controller_suite_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	testNamespaceConst         = "test-namespace"
+	testNamespaceConst         = ""
 	testNameForAnnotationTests = "rsc-test-annotation"
 )
 

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -179,8 +179,7 @@ func ReconcileReplicatedStorageClassEvent(
 			return false, nil
 		}
 
-		return true, fmt.Errorf("[ReconcileReplicatedStorageClassEvent] "+
-			"error getting ReplicatedStorageClass: %w", err)
+		return true, fmt.Errorf("error getting ReplicatedStorageClass: %w", err)
 	}
 
 	sc, err := GetStorageClass(ctx, cl, replicatedSC.Namespace, replicatedSC.Name)
@@ -189,14 +188,12 @@ func ReconcileReplicatedStorageClassEvent(
 			log.Info("[ReconcileReplicatedStorageClassEvent] StorageClass with name: " +
 				replicatedSC.Name + " not found.")
 		} else {
-			return true, fmt.Errorf("[ReconcileReplicatedStorageClassEvent] error getting StorageClass: %s",
-				err.Error())
+			return true, fmt.Errorf("error getting StorageClass: %w", err)
 		}
 	}
 
 	if sc != nil && sc.Provisioner != StorageClassProvisioner {
-		return false, fmt.Errorf("[ReconcileReplicatedStorageClassEvent] "+
-			"Reconcile StorageClass with provisioner %s is not allowed", sc.Provisioner)
+		return false, fmt.Errorf("Reconcile StorageClass with provisioner %s is not allowed", sc.Provisioner)
 	}
 
 	// Handle deletion
@@ -275,8 +272,7 @@ func ReconcileReplicatedStorageClass(
 			replicatedSC.Name + " not found. Create it.")
 		log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClass] create StorageClass %+v", newSC))
 		if err = CreateStorageClass(ctx, cl, newSC); err != nil {
-			return true, fmt.Errorf("[ReconcileReplicatedStorageClass] error CreateStorageClass %s: %w",
-				replicatedSC.Name, err)
+			return true, fmt.Errorf("error CreateStorageClass %s: %w", replicatedSC.Name, err)
 		}
 		log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " created.")
 	} else {
@@ -284,8 +280,7 @@ func ReconcileReplicatedStorageClass(
 			" storage class if needed.")
 		shouldRequeue, err := UpdateStorageClassIfNeeded(ctx, cl, log, newSC, oldSC)
 		if err != nil {
-			return shouldRequeue, fmt.Errorf("[ReconcileReplicatedStorageClass] "+
-				"error updateStorageClassIfNeeded: %w", err)
+			return shouldRequeue, fmt.Errorf("error updateStorageClassIfNeeded: %w", err)
 		}
 	}
 
@@ -325,8 +320,7 @@ func ReconcileDeleteReplicatedStorageClass(
 			" found. Deleting it.")
 
 		if err := DeleteStorageClass(ctx, cl, sc); err != nil {
-			return true, fmt.Errorf("[ReconcileDeleteReplicatedStorageClass] error DeleteStorageClass: %s",
-				err.Error())
+			return true, fmt.Errorf("error DeleteStorageClass: %w", err)
 		}
 		log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
 			" deleted.")
@@ -338,8 +332,7 @@ func ReconcileDeleteReplicatedStorageClass(
 	replicatedSC.ObjectMeta.Finalizers = RemoveString(replicatedSC.ObjectMeta.Finalizers,
 		ReplicatedStorageClassFinalizerName)
 	if err := UpdateReplicatedStorageClass(ctx, cl, replicatedSC); err != nil {
-		return true, fmt.Errorf("[ReconcileDeleteReplicatedStorageClass] error UpdateReplicatedStorageClass "+
-			"after removing finalizer: %s", err.Error())
+		return true, fmt.Errorf("error UpdateReplicatedStorageClass after removing finalizer: %w", err)
 	}
 
 	log.Info("[ReconcileDeleteReplicatedStorageClass] Finalizer removed from ReplicatedStorageClass with name: " +

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -599,9 +599,11 @@ func updateStorageClassMetaDataIfNeeded(
 	cl client.Client,
 	newSC, oldSC *storagev1.StorageClass,
 ) error {
-	needsUpdate := !reflect.DeepEqual(oldSC.Labels, newSC.Labels) ||
-		!reflect.DeepEqual(oldSC.Annotations, newSC.Annotations) ||
-		!reflect.DeepEqual(oldSC.Finalizers, newSC.Finalizers)
+	needsUpdate := !maps.Equal(oldSC.Labels, newSC.Labels) ||
+		!maps.Equal(oldSC.Annotations, newSC.Annotations) ||
+		!slices.EqualFunc(newSC.Finalizers, oldSC.Finalizers, func(a, b string) bool {
+			return a == b
+		})
 
 	if !needsUpdate {
 		return nil

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -47,6 +47,7 @@ import (
 const (
 	ReplicatedStorageClassControllerName = "replicated-storage-class-controller"
 	ReplicatedStorageClassFinalizerName  = "replicatedstorageclass.storage.deckhouse.io"
+	StorageClassFinalizerName            = "storage.deckhouse.io/sds-replicated-volume"
 	StorageClassProvisioner              = "replicated.csi.storage.deckhouse.io"
 	StorageClassKind                     = "StorageClass"
 	StorageClassAPIVersion               = "storage.k8s.io/v1"
@@ -157,28 +158,67 @@ func NewReplicatedStorageClass(
 	return c, err
 }
 
-func ReconcileReplicatedStorageClassEvent(ctx context.Context, cl client.Client, log logger.Logger, cfg *config.Options, request reconcile.Request) (bool, error) {
-	log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClassEvent] Try to get ReplicatedStorageClass with name: %s", request.Name))
+func ReconcileReplicatedStorageClassEvent(
+	ctx context.Context,
+	cl client.Client,
+	log logger.Logger,
+	cfg *config.Options,
+	request reconcile.Request,
+) (bool, error) {
+	log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClassEvent] Try to get ReplicatedStorageClass with name: %s",
+		request.Name))
 
 	replicatedSC, err := GetReplicatedStorageClass(ctx, cl, request.Namespace, request.Name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			log.Info(fmt.Sprintf("[ReconcileReplicatedStorageClassEvent] ReplicatedStorageClass with name: %s not found. Finish reconcile.", request.Name))
+			log.Info(fmt.Sprintf("[ReconcileReplicatedStorageClassEvent] "+
+				"ReplicatedStorageClass with name: %s not found. Finish reconcile.", request.Name))
 			return false, nil
 		}
 
-		return true, fmt.Errorf("[ReconcileReplicatedStorageClassEvent] error getting ReplicatedStorageClass: %w", err)
+		return true, fmt.Errorf("[ReconcileReplicatedStorageClassEvent] "+
+			"error getting ReplicatedStorageClass: %w", err)
 	}
 
-	shouldRequeue, err := ReconcileReplicatedStorageClass(ctx, cl, log, cfg, replicatedSC)
+	sc, err := GetStorageClass(ctx, cl, replicatedSC.Namespace, replicatedSC.Name)
 	if err != nil {
-		replicatedSC.Status.Phase = Failed
-		replicatedSC.Status.Reason = err.Error()
-		log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClass] update ReplicatedStorageClass %+v", replicatedSC))
-		if updateErr := UpdateReplicatedStorageClass(ctx, cl, replicatedSC); updateErr != nil {
-			// save err and add new error to it
+		if k8serrors.IsNotFound(err) {
+			log.Info("[ReconcileReplicatedStorageClassEvent] StorageClass with name: " +
+				replicatedSC.Name + " not found.")
+		} else {
+			return true, fmt.Errorf("[ReconcileReplicatedStorageClassEvent] error getting StorageClass: %s",
+				err.Error())
+		}
+	}
+
+	if sc != nil && sc.Provisioner != StorageClassProvisioner {
+		return false, fmt.Errorf("[ReconcileReplicatedStorageClassEvent] "+
+			"Reconcile StorageClass with provisioner %s is not allowed", sc.Provisioner)
+	}
+
+	// Handle deletion
+	if replicatedSC.ObjectMeta.DeletionTimestamp != nil {
+		log.Info("[ReconcileReplicatedStorageClass] ReplicatedStorageClass with name: " +
+			replicatedSC.Name + " is marked for deletion. Removing it.")
+		shouldRequeue, err := ReconcileDeleteReplicatedStorageClass(ctx, cl, log, replicatedSC, sc)
+		if err != nil {
+			if updateErr := updateReplicatedStorageClassStatus(ctx, cl, log, replicatedSC, Failed, err.Error()); updateErr != nil {
+				err = errors.Join(err, updateErr)
+				err = fmt.Errorf("[ReconcileReplicatedStorageClassEvent] error after "+
+					"ReconcileDeleteReplicatedStorageClass and error after UpdateReplicatedStorageClass: %w", err)
+				shouldRequeue = true
+			}
+		}
+		return shouldRequeue, err
+	}
+
+	// Normal reconciliation
+	shouldRequeue, err := ReconcileReplicatedStorageClass(ctx, cl, log, cfg, replicatedSC, sc)
+	if err != nil {
+		if updateErr := updateReplicatedStorageClassStatus(ctx, cl, log, replicatedSC, Failed, err.Error()); updateErr != nil {
 			err = errors.Join(err, updateErr)
-			err = fmt.Errorf("[ReconcileReplicatedStorageClassEvent] error after ReconcileReplicatedStorageClass and error after UpdateReplicatedStorageClass: %w", err)
+			err = fmt.Errorf("[ReconcileReplicatedStorageClassEvent] error after ReconcileReplicatedStorageClass"+
+				"and error after UpdateReplicatedStorageClass: %w", err)
 			shouldRequeue = true
 		}
 	}
@@ -186,40 +226,14 @@ func ReconcileReplicatedStorageClassEvent(ctx context.Context, cl client.Client,
 	return shouldRequeue, err
 }
 
-func ReconcileReplicatedStorageClass(ctx context.Context, cl client.Client, log logger.Logger, cfg *config.Options, replicatedSC *srv.ReplicatedStorageClass) (bool, error) {
-	if replicatedSC.ObjectMeta.DeletionTimestamp != nil {
-		log.Info("[ReconcileReplicatedStorageClass] ReplicatedStorageClass with name: " + replicatedSC.Name + " is marked for deletion. Removing it.")
-		switch replicatedSC.Status.Phase {
-		case Failed:
-			log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " was not deleted because the ReplicatedStorageClass is in a Failed state. Deleting only finalizer.")
-		case Created:
-			sc, err := GetStorageClass(ctx, cl, replicatedSC.Namespace, replicatedSC.Name)
-			if err != nil {
-				if k8serrors.IsNotFound(err) {
-					log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " not found. No need to delete it.")
-					break
-				}
-				return true, fmt.Errorf("[ReconcileReplicatedStorageClass] error getting StorageClass: %s", err.Error())
-			}
-
-			log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " found. Deleting it.")
-			if err := DeleteStorageClass(ctx, cl, sc); err != nil {
-				return true, fmt.Errorf("[ReconcileReplicatedStorageClass] error DeleteStorageClass: %s", err.Error())
-			}
-			log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " deleted.")
-		}
-
-		log.Info("[ReconcileReplicatedStorageClass] Removing finalizer from ReplicatedStorageClass with name: " + replicatedSC.Name)
-
-		replicatedSC.ObjectMeta.Finalizers = RemoveString(replicatedSC.ObjectMeta.Finalizers, ReplicatedStorageClassFinalizerName)
-		if err := UpdateReplicatedStorageClass(ctx, cl, replicatedSC); err != nil {
-			return true, fmt.Errorf("[ReconcileReplicatedStorageClass] error UpdateReplicatedStorageClass after removing finalizer: %s", err.Error())
-		}
-
-		log.Info("[ReconcileReplicatedStorageClass] Finalizer removed from ReplicatedStorageClass with name: " + replicatedSC.Name)
-		return false, nil
-	}
-
+func ReconcileReplicatedStorageClass(
+	ctx context.Context,
+	cl client.Client,
+	log logger.Logger,
+	cfg *config.Options,
+	replicatedSC *srv.ReplicatedStorageClass,
+	oldSC *storagev1.StorageClass,
+) (bool, error) {
 	log.Info("[ReconcileReplicatedStorageClass] Validating ReplicatedStorageClass with name: " + replicatedSC.Name)
 
 	zones, err := GetClusterZones(ctx, cl)
@@ -230,51 +244,53 @@ func ReconcileReplicatedStorageClass(ctx context.Context, cl client.Client, log 
 
 	valid, msg := ValidateReplicatedStorageClass(replicatedSC, zones)
 	if !valid {
-		err := fmt.Errorf("[ReconcileReplicatedStorageClass] Validation of ReplicatedStorageClass %s failed for the following reason: %s", replicatedSC.Name, msg)
+		err := fmt.Errorf("[ReconcileReplicatedStorageClass] Validation of "+
+			"ReplicatedStorageClass %s failed for the following reason: %s", replicatedSC.Name, msg)
 		return false, err
 	}
-	log.Info("[ReconcileReplicatedStorageClass] ReplicatedStorageClass with name: " + replicatedSC.Name + " is valid")
+	log.Info("[ReconcileReplicatedStorageClass] ReplicatedStorageClass with name: " +
+		replicatedSC.Name + " is valid")
 
-	log.Info("[ReconcileReplicatedStorageClass] Try to get StorageClass with name: " + replicatedSC.Name)
-	oldSC, err := GetStorageClass(ctx, cl, replicatedSC.Namespace, replicatedSC.Name)
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return true, fmt.Errorf("[ReconcileReplicatedStorageClass] error getting StorageClass: %w", err)
-		}
-	}
-
-	log.Trace("[ReconcileReplicatedStorageClass] Check if virtualization module is enabled and if the ReplicatedStorageClass has VolumeAccess set to Local")
+	log.Trace("[ReconcileReplicatedStorageClass] Check if virtualization module is enabled and if " +
+		"the ReplicatedStorageClass has VolumeAccess set to Local")
 	var virtualizationEnabled bool
 	if replicatedSC.Spec.VolumeAccess == VolumeAccessLocal {
-		virtualizationEnabled, err = GetVirtualizationModuleEnabled(ctx, cl, log, types.NamespacedName{Name: ControllerConfigMapName, Namespace: cfg.ControllerNamespace})
+		virtualizationEnabled, err = GetVirtualizationModuleEnabled(ctx, cl, log,
+			types.NamespacedName{Name: ControllerConfigMapName, Namespace: cfg.ControllerNamespace})
 		if err != nil {
 			err = fmt.Errorf("[ReconcileReplicatedStorageClass] error GetVirtualizationModuleEnabled: %w", err)
 			return true, err
 		}
-		log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClass] ReplicatedStorageClass has VolumeAccess set to Local and virtualization module is %t", virtualizationEnabled))
+		log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClass] ReplicatedStorageClass has VolumeAccess set "+
+			"to Local and virtualization module is %t", virtualizationEnabled))
 	}
 
+	newSC := GetNewStorageClass(replicatedSC, virtualizationEnabled)
+
 	if oldSC == nil {
-		log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " not found. Create it.")
-		newSC := GetNewStorageClass(replicatedSC, virtualizationEnabled)
+		log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " +
+			replicatedSC.Name + " not found. Create it.")
 		log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClass] create StorageClass %+v", newSC))
 		if err = CreateStorageClass(ctx, cl, newSC); err != nil {
-			return true, fmt.Errorf("[ReconcileReplicatedStorageClass] error CreateStorageClass %s: %w", replicatedSC.Name, err)
+			return true, fmt.Errorf("[ReconcileReplicatedStorageClass] error CreateStorageClass %s: %w",
+				replicatedSC.Name, err)
 		}
 		log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " created.")
 	} else {
-		log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name + " found. Update it if needed.")
-
-		shouldRequeue, err := UpdateStorageClassIfNeeded(ctx, cl, log, replicatedSC, oldSC, virtualizationEnabled)
+		log.Info("[ReconcileReplicatedStorageClass] StorageClass with name: Update " + replicatedSC.Name +
+			" storage class if needed.")
+		shouldRequeue, err := UpdateStorageClassIfNeeded(ctx, cl, log, newSC, oldSC)
 		if err != nil {
-			return shouldRequeue, fmt.Errorf("[ReconcileReplicatedStorageClass] error updateStorageClassIfNeeded: %w", err)
+			return shouldRequeue, fmt.Errorf("[ReconcileReplicatedStorageClass] "+
+				"error updateStorageClassIfNeeded: %w", err)
 		}
 	}
 
 	replicatedSC.Status.Phase = Created
 	replicatedSC.Status.Reason = "ReplicatedStorageClass and StorageClass are equal."
 	if !slices.Contains(replicatedSC.ObjectMeta.Finalizers, ReplicatedStorageClassFinalizerName) {
-		replicatedSC.ObjectMeta.Finalizers = append(replicatedSC.ObjectMeta.Finalizers, ReplicatedStorageClassFinalizerName)
+		replicatedSC.ObjectMeta.Finalizers = append(replicatedSC.ObjectMeta.Finalizers,
+			ReplicatedStorageClassFinalizerName)
 	}
 	log.Trace(fmt.Sprintf("[ReconcileReplicatedStorageClassEvent] update ReplicatedStorageClass %+v", replicatedSC))
 	if err = UpdateReplicatedStorageClass(ctx, cl, replicatedSC); err != nil {
@@ -282,6 +298,49 @@ func ReconcileReplicatedStorageClass(ctx context.Context, cl client.Client, log 
 		return true, err
 	}
 
+	return false, nil
+}
+
+func ReconcileDeleteReplicatedStorageClass(
+	ctx context.Context,
+	cl client.Client,
+	log logger.Logger,
+	replicatedSC *srv.ReplicatedStorageClass,
+	sc *storagev1.StorageClass,
+) (bool, error) {
+	switch replicatedSC.Status.Phase {
+	case Failed:
+		log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
+			" was not deleted because the ReplicatedStorageClass is in a Failed state. Deleting only finalizer.")
+	case Created:
+		log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
+			" found. Deleting it.")
+		if sc == nil {
+			log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
+				" no need to delete.")
+			break
+		}
+
+		if err := DeleteStorageClass(ctx, cl, sc); err != nil {
+			return true, fmt.Errorf("[ReconcileDeleteReplicatedStorageClass] error DeleteStorageClass: %s",
+				err.Error())
+		}
+		log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
+			" deleted.")
+	}
+
+	log.Info("[ReconcileDeleteReplicatedStorageClass] Removing finalizer from ReplicatedStorageClass with name: " +
+		replicatedSC.Name)
+
+	replicatedSC.ObjectMeta.Finalizers = RemoveString(replicatedSC.ObjectMeta.Finalizers,
+		ReplicatedStorageClassFinalizerName)
+	if err := UpdateReplicatedStorageClass(ctx, cl, replicatedSC); err != nil {
+		return true, fmt.Errorf("[ReconcileDeleteReplicatedStorageClass] error UpdateReplicatedStorageClass "+
+			"after removing finalizer: %s", err.Error())
+	}
+
+	log.Info("[ReconcileDeleteReplicatedStorageClass] Finalizer removed from ReplicatedStorageClass with name: " +
+		replicatedSC.Name)
 	return false, nil
 }
 
@@ -368,7 +427,7 @@ func UpdateReplicatedStorageClass(ctx context.Context, cl client.Client, replica
 	return nil
 }
 
-func CompareStorageClasses(oldSC, newSC *storagev1.StorageClass) (bool, string) {
+func CompareStorageClasses(newSC, oldSC *storagev1.StorageClass) (bool, string) {
 	var (
 		failedMsgBuilder strings.Builder
 		equal            = true
@@ -477,8 +536,10 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *srv.Replicated
 			Name:            replicatedSC.Name,
 			Namespace:       replicatedSC.Namespace,
 			OwnerReferences: nil,
-			Finalizers:      nil,
+			Finalizers:      []string{StorageClassFinalizerName},
 			ManagedFields:   nil,
+			Labels:          map[string]string{ManagedLabelKey: ManagedLabelValue},
+			Annotations:     nil,
 		},
 		AllowVolumeExpansion: &allowVolumeExpansion,
 		Parameters:           storageClassParameters,
@@ -496,6 +557,10 @@ func GetReplicatedStorageClass(ctx context.Context, cl client.Client, namespace,
 		Name:      name,
 		Namespace: namespace,
 	}, replicatedSC)
+
+	if err != nil {
+		return nil, err
+	}
 
 	return replicatedSC, err
 }
@@ -515,49 +580,77 @@ func GetStorageClass(ctx context.Context, cl client.Client, namespace, name stri
 }
 
 func DeleteStorageClass(ctx context.Context, cl client.Client, sc *storagev1.StorageClass) error {
-	return cl.Delete(ctx, sc)
-}
-
-func RemoveString(slice []string, s string) (result []string) {
-	for _, value := range slice {
-		if value != s {
-			result = append(result, value)
+	finalizers := sc.ObjectMeta.Finalizers
+	switch len(finalizers) {
+	case 0:
+		return cl.Delete(ctx, sc)
+	case 1:
+		if finalizers[0] != StorageClassFinalizerName {
+			return fmt.Errorf("deletion of StorageClass with finalizer %s is not allowed", finalizers[0])
 		}
+		sc.ObjectMeta.Finalizers = nil
+		if err := cl.Update(ctx, sc); err != nil {
+			return fmt.Errorf("error updating StorageClass to remove finalizer %s: %w",
+				StorageClassFinalizerName, err)
+		}
+		return cl.Delete(ctx, sc)
 	}
-	return
+	// The finalizers list contains more than one element — return an error
+	return fmt.Errorf("deletion of StorageClass with multiple(%v) finalizers is not allowed", finalizers)
 }
 
-func ReconcileStorageClassLabelsAndAnnotationsIfNeeded(ctx context.Context, cl client.Client, oldSC, newSC *storagev1.StorageClass) error {
-	if !reflect.DeepEqual(oldSC.Labels, newSC.Labels) || !reflect.DeepEqual(oldSC.Annotations, newSC.Annotations) {
-		oldSC.Labels = newSC.Labels
-		oldSC.Annotations = newSC.Annotations
-		return cl.Update(ctx, oldSC)
+func updateStorageClassMetaDataIfNeeded(
+	ctx context.Context,
+	cl client.Client,
+	newSC, oldSC *storagev1.StorageClass,
+) error {
+	needsUpdate := !reflect.DeepEqual(oldSC.Labels, newSC.Labels) ||
+		!reflect.DeepEqual(oldSC.Annotations, newSC.Annotations) ||
+		!reflect.DeepEqual(oldSC.Finalizers, newSC.Finalizers)
+
+	if !needsUpdate {
+		return nil
 	}
-	return nil
+
+	oldSC.Labels = copyMap(newSC.Labels)
+	oldSC.Annotations = copyMap(newSC.Annotations)
+	oldSC.Finalizers = append([]string{}, newSC.Finalizers...)
+
+	return cl.Update(ctx, oldSC)
 }
 
-func canRecreateStorageClass(oldSC, newSC *storagev1.StorageClass) (bool, string) {
+func canRecreateStorageClass(newSC, oldSC *storagev1.StorageClass) (bool, string) {
 	newSCCopy := newSC.DeepCopy()
 	oldSCCopy := oldSC.DeepCopy()
 
-	// We can recreate StorageClass only if the following parameters are not equal. If other parameters are not equal, we can't recreate StorageClass and users must delete ReplicatedStorageClass resource and create it again manually.
+	// We can recreate StorageClass only if the following parameters are not equal.
+	// If other parameters are not equal, we can't recreate StorageClass and
+	// users must delete ReplicatedStorageClass resource and create it again manually.
 	delete(newSCCopy.Parameters, QuorumMinimumRedundancyWithPrefixSCKey)
 	delete(oldSCCopy.Parameters, QuorumMinimumRedundancyWithPrefixSCKey)
 	return CompareStorageClasses(newSCCopy, oldSCCopy)
 }
 
-func recreateStorageClassIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, oldSC, newSC *storagev1.StorageClass) (isRecreated, shouldRequeue bool, err error) {
+func recreateStorageClassIfNeeded(
+	ctx context.Context,
+	cl client.Client,
+	log logger.Logger,
+	newSC, oldSC *storagev1.StorageClass,
+) (isRecreated, shouldRequeue bool, err error) {
 	equal, msg := CompareStorageClasses(newSC, oldSC)
 	log.Trace(fmt.Sprintf("[recreateStorageClassIfNeeded] msg after compare: %s", msg))
 	if equal {
-		log.Info("[recreateStorageClassIfNeeded] Old and new StorageClass are equal. No need to recreate StorageClass.")
+		log.Info("[recreateStorageClassIfNeeded] Old and new StorageClass are equal." +
+			"No need to recreate StorageClass.")
 		return false, false, nil
 	}
 
-	log.Info("[recreateStorageClassIfNeeded] ReplicatedStorageClass and StorageClass are not equal. Check if StorageClass can be recreated.")
-	canRecreate, msg := canRecreateStorageClass(oldSC, newSC)
+	log.Info("[recreateStorageClassIfNeeded] ReplicatedStorageClass and StorageClass are not equal." +
+		"Check if StorageClass can be recreated.")
+	canRecreate, msg := canRecreateStorageClass(newSC, oldSC)
 	if !canRecreate {
-		err := fmt.Errorf("[recreateStorageClassIfNeeded] The StorageClass cannot be recreated because its parameters are not equal: %s", msg)
+		err := fmt.Errorf("[recreateStorageClassIfNeeded] The StorageClass cannot be recreated because "+
+			"its parameters are not equal: %s", msg)
 		return false, false, err
 	}
 
@@ -578,56 +671,119 @@ func recreateStorageClassIfNeeded(ctx context.Context, cl client.Client, log log
 
 func GetNewStorageClass(replicatedSC *srv.ReplicatedStorageClass, virtualizationEnabled bool) *storagev1.StorageClass {
 	newSC := GenerateStorageClassFromReplicatedStorageClass(replicatedSC)
-	newSC.Labels = map[string]string{ManagedLabelKey: ManagedLabelValue}
 	if replicatedSC.Spec.VolumeAccess == VolumeAccessLocal && virtualizationEnabled {
-		newSC.Annotations = map[string]string{StorageClassVirtualizationAnnotationKey: StorageClassVirtualizationAnnotationValue}
-	}
-	return newSC
-}
-
-func GetUpdatedStorageClass(replicatedSC *srv.ReplicatedStorageClass, oldSC *storagev1.StorageClass, virtualizationEnabled bool) *storagev1.StorageClass {
-	newSC := GenerateStorageClassFromReplicatedStorageClass(replicatedSC)
-
-	newSC.Labels = make(map[string]string, len(oldSC.Labels))
-	for k, v := range oldSC.Labels {
-		newSC.Labels[k] = v
-	}
-	newSC.Labels[ManagedLabelKey] = ManagedLabelValue
-
-	newSC.Annotations = make(map[string]string, len(oldSC.Annotations))
-	for k, v := range oldSC.Annotations {
-		newSC.Annotations[k] = v
-	}
-
-	if replicatedSC.Spec.VolumeAccess == VolumeAccessLocal && virtualizationEnabled {
+		if newSC.Annotations == nil {
+			newSC.Annotations = make(map[string]string, 1)
+		}
 		newSC.Annotations[StorageClassVirtualizationAnnotationKey] = StorageClassVirtualizationAnnotationValue
-	} else {
-		delete(newSC.Annotations, StorageClassVirtualizationAnnotationKey)
 	}
-
-	if len(newSC.Annotations) == 0 {
-		newSC.Annotations = nil
-	}
-
 	return newSC
 }
 
-func UpdateStorageClassIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, replicatedSC *srv.ReplicatedStorageClass, oldSC *storagev1.StorageClass, virtualizationEnabled bool) (bool, error) {
-	newSC := GetUpdatedStorageClass(replicatedSC, oldSC, virtualizationEnabled)
-	log.Trace(fmt.Sprintf("[UpdateStorageClassIfNeeded] old StorageClass %+v", oldSC))
-	log.Trace(fmt.Sprintf("[UpdateStorageClassIfNeeded] updated StorageClass %+v", newSC))
-
-	isRecreated, shouldRequeue, err := recreateStorageClassIfNeeded(ctx, cl, log, oldSC, newSC)
-	if err != nil {
-		return shouldRequeue, err
-	}
-
-	if !isRecreated {
-		err := ReconcileStorageClassLabelsAndAnnotationsIfNeeded(ctx, cl, oldSC, newSC)
-		if err != nil {
-			return true, err
+func DoUpdateStorageClass(
+	newSC *storagev1.StorageClass,
+	oldSC *storagev1.StorageClass,
+) {
+	// Copy Labels from oldSC to newSC if they do not exist in newSC
+	if len(oldSC.Labels) > 0 {
+		if newSC.Labels == nil {
+			newSC.Labels = copyMap(oldSC.Labels)
+		} else {
+			updateMap(newSC.Labels, oldSC.Labels, false)
 		}
 	}
 
+	copyAnotations := copyMap(oldSC.Annotations)
+	delete(copyAnotations, StorageClassVirtualizationAnnotationKey)
+
+	// Copy relevant Annotations from oldSC to newSC, excluding StorageClassVirtualizationAnnotationKey
+	if len(copyAnotations) > 0 {
+		if newSC.Annotations == nil {
+			newSC.Annotations = copyAnotations
+		} else {
+			updateMap(newSC.Annotations, oldSC.Annotations, false)
+		}
+	}
+
+	// Copy Finalizers from oldSC to newSC, avoiding duplicates
+	if len(oldSC.Finalizers) > 0 {
+		finalizersSet := make(map[string]struct{}, len(newSC.Finalizers))
+		for _, f := range newSC.Finalizers {
+			finalizersSet[f] = struct{}{}
+		}
+		for _, f := range oldSC.Finalizers {
+			if _, exists := finalizersSet[f]; !exists {
+				newSC.Finalizers = append(newSC.Finalizers, f)
+				finalizersSet[f] = struct{}{}
+			}
+		}
+	}
+}
+
+func UpdateStorageClassIfNeeded(
+	ctx context.Context,
+	cl client.Client,
+	log logger.Logger,
+	newSC *storagev1.StorageClass,
+	oldSC *storagev1.StorageClass,
+) (bool, error) {
+	DoUpdateStorageClass(newSC, oldSC)
+	log.Trace(fmt.Sprintf("[UpdateStorageClassIfNeeded] old StorageClass %+v", oldSC))
+	log.Trace(fmt.Sprintf("[UpdateStorageClassIfNeeded] updated StorageClass %+v", newSC))
+
+	isRecreated, shouldRequeue, err := recreateStorageClassIfNeeded(ctx, cl, log, newSC, oldSC)
+	if err != nil || isRecreated {
+		return shouldRequeue, err
+	}
+
+	if err := updateStorageClassMetaDataIfNeeded(ctx, cl, newSC, oldSC); err != nil {
+		return true, err
+	}
+
 	return shouldRequeue, nil
+}
+
+func RemoveString(slice []string, s string) (result []string) {
+	for _, value := range slice {
+		if value != s {
+			result = append(result, value)
+		}
+	}
+	return
+}
+
+func updateReplicatedStorageClassStatus(
+	ctx context.Context,
+	cl client.Client,
+	log logger.Logger,
+	replicatedSC *srv.ReplicatedStorageClass,
+	phase string,
+	reason string,
+) error {
+	replicatedSC.Status.Phase = phase
+	replicatedSC.Status.Reason = reason
+	log.Trace(fmt.Sprintf("[updateReplicatedStorageClassStatus] update ReplicatedStorageClass %+v", replicatedSC))
+	return UpdateReplicatedStorageClass(ctx, cl, replicatedSC)
+}
+
+func copyMap(m map[string]string) map[string]string {
+	copied := make(map[string]string, len(m))
+	for k, v := range m {
+		copied[k] = v
+	}
+	return copied
+}
+
+func updateMap(dst, src map[string]string, rw bool) {
+	if rw {
+		for k, v := range src {
+			dst[k] = v
+		}
+	} else {
+		for k, v := range src {
+			if _, exists := dst[k]; !exists {
+				dst[k] = v
+			}
+		}
+	}
 }

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -47,9 +47,9 @@ import (
 
 const (
 	ReplicatedStorageClassControllerName = "replicated-storage-class-controller"
-	// ???
+	// TODO
 	ReplicatedStorageClassFinalizerName = "replicatedstorageclass.storage.deckhouse.io"
-	// ???
+	// TODO
 	StorageClassFinalizerName = "storage.deckhouse.io/sds-replicated-volume"
 	StorageClassProvisioner   = "replicated.csi.storage.deckhouse.io"
 	StorageClassKind          = "StorageClass"

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -692,7 +692,7 @@ func DoUpdateStorageClass(
 		if newSC.Labels == nil {
 			newSC.Labels = maps.Clone(oldSC.Labels)
 		} else {
-			updateMap(newSC.Labels, oldSC.Labels, false)
+			updateMap(newSC.Labels, oldSC.Labels)
 		}
 	}
 
@@ -704,7 +704,7 @@ func DoUpdateStorageClass(
 		if newSC.Annotations == nil {
 			newSC.Annotations = copyAnnotations
 		} else {
-			updateMap(newSC.Annotations, copyAnnotations, false)
+			updateMap(newSC.Annotations, copyAnnotations)
 		}
 	}
 
@@ -769,16 +769,10 @@ func updateReplicatedStorageClassStatus(
 	return UpdateReplicatedStorageClass(ctx, cl, replicatedSC)
 }
 
-func updateMap(dst, src map[string]string, rw bool) {
-	if rw {
-		for k, v := range src {
+func updateMap(dst, src map[string]string) {
+	for k, v := range src {
+		if _, exists := dst[k]; !exists {
 			dst[k] = v
-		}
-	} else {
-		for k, v := range src {
-			if _, exists := dst[k]; !exists {
-				dst[k] = v
-			}
 		}
 	}
 }

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -182,7 +182,7 @@ func ReconcileReplicatedStorageClassEvent(
 		return true, fmt.Errorf("error getting ReplicatedStorageClass: %w", err)
 	}
 
-	sc, err := GetStorageClass(ctx, cl, replicatedSC.Namespace, replicatedSC.Name)
+	sc, err := GetStorageClass(ctx, cl, replicatedSC.Name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Info("[ReconcileReplicatedStorageClassEvent] StorageClass with name: " +
@@ -561,11 +561,10 @@ func GetReplicatedStorageClass(ctx context.Context, cl client.Client, namespace,
 	return replicatedSC, err
 }
 
-func GetStorageClass(ctx context.Context, cl client.Client, namespace, name string) (*storagev1.StorageClass, error) {
+func GetStorageClass(ctx context.Context, cl client.Client, name string) (*storagev1.StorageClass, error) {
 	sc := &storagev1.StorageClass{}
 	err := cl.Get(ctx, client.ObjectKey{
-		Name:      name,
-		Namespace: namespace,
+		Name: name,
 	}, sc)
 
 	if err != nil {

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -696,15 +696,15 @@ func DoUpdateStorageClass(
 		}
 	}
 
-	copyAnotations := maps.Clone(oldSC.Annotations)
-	delete(copyAnotations, StorageClassVirtualizationAnnotationKey)
+	copyAnnotations := maps.Clone(oldSC.Annotations)
+	delete(copyAnnotations, StorageClassVirtualizationAnnotationKey)
 
 	// Copy relevant Annotations from oldSC to newSC, excluding StorageClassVirtualizationAnnotationKey
-	if len(copyAnotations) > 0 {
+	if len(copyAnnotations) > 0 {
 		if newSC.Annotations == nil {
-			newSC.Annotations = copyAnotations
+			newSC.Annotations = copyAnnotations
 		} else {
-			updateMap(newSC.Annotations, oldSC.Annotations, false)
+			updateMap(newSC.Annotations, copyAnnotations, false)
 		}
 	}
 

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class.go
@@ -316,13 +316,13 @@ func ReconcileDeleteReplicatedStorageClass(
 		log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
 			" was not deleted because the ReplicatedStorageClass is in a Failed state. Deleting only finalizer.")
 	case Created:
-		log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
-			" found. Deleting it.")
 		if sc == nil {
 			log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
 				" no need to delete.")
 			break
 		}
+		log.Info("[ReconcileDeleteReplicatedStorageClass] StorageClass with name: " + replicatedSC.Name +
+			" found. Deleting it.")
 
 		if err := DeleteStorageClass(ctx, cl, sc); err != nil {
 			return true, fmt.Errorf("[ReconcileDeleteReplicatedStorageClass] error DeleteStorageClass: %s",

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class_test.go
@@ -150,7 +150,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		}
 		Expect(err).NotTo(HaveOccurred())
 
-		sc, err := controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		sc, err := controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sc).NotTo(BeNil())
 		Expect(sc.Name).To(Equal(testName))
@@ -185,7 +185,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		err = controller.DeleteStorageClass(ctx, cl, storageClass)
 		Expect(err).NotTo(HaveOccurred())
 
-		sc, err := controller.GetStorageClass(ctx, cl, testName, testNamespaceConst)
+		sc, err := controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).NotTo(BeNil())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 		Expect(sc).To(BeNil())
@@ -207,7 +207,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		}
 		Expect(err).NotTo(HaveOccurred())
 
-		sc, err = controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		sc, err = controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sc).NotTo(BeNil())
 		Expect(sc.Name).To(Equal(testName))
@@ -381,7 +381,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(reflect.ValueOf(resources[testName]).IsZero()).To(BeTrue())
 
-		sc, err := controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		sc, err := controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 		Expect(sc).To(BeNil())
@@ -432,7 +432,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 
-		storageClass, err := controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		storageClass, err := controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(storageClass).NotTo(BeNil())
 		Expect(storageClass.Name).To(Equal(testName))
@@ -680,7 +680,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		replicatedSC = getAndValidateNotReconciledRSC(ctx, cl, testName)
 
-		storageClass, err := controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		storageClass, err := controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 		Expect(storageClass).To(BeNil())
@@ -699,7 +699,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		Expect(slices.Contains(resource.Finalizers, controller.ReplicatedStorageClassFinalizerName)).To(BeTrue())
 
-		storageClass, err = controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		storageClass, err = controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(storageClass).NotTo(BeNil())
 		Expect(storageClass.Name).To(Equal(testName))
@@ -764,7 +764,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		resFinalizers := strings.Join(resource.Finalizers, "")
 		Expect(strings.Contains(resFinalizers, controller.ReplicatedStorageClassFinalizerName))
 
-		storageClass, err := controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		storageClass, err := controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(storageClass).NotTo(BeNil())
 		Expect(storageClass.Name).To(Equal(testName))
@@ -822,7 +822,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSCafterReconcile.Name).To(Equal(testName))
 		Expect(replicatedSCafterReconcile.Status.Phase).To(Equal(controller.Failed))
 
-		storageClass, err := controller.GetStorageClass(ctx, cl, testNamespaceConst, testName)
+		storageClass, err := controller.GetStorageClass(ctx, cl, testName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(storageClass).NotTo(BeNil())
 		Expect(storageClass.Name).To(Equal(testName))

--- a/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/src/pkg/controller/replicated_storage_class_test.go
@@ -788,7 +788,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 			},
 		}
 
-		failedMessage := "[ReconcileReplicatedStorageClass] error updateStorageClassIfNeeded: " +
+		failedMessage := "error updateStorageClassIfNeeded: " +
 			"[recreateStorageClassIfNeeded] The StorageClass cannot be recreated because its parameters are not equal: " +
 			"Old StorageClass and New StorageClass are not equal: ReclaimPolicy are not equal " +
 			"(Old StorageClass: not-equal, New StorageClass: Retain"

--- a/images/webhooks/src/go.sum
+++ b/images/webhooks/src/go.sum
@@ -7,10 +7,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240805103635-969dc811217b h1:EYmHWTWcWMpyxJGZK05ZxlIFnh9s66DRrxLw/LNb/xw=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240805103635-969dc811217b/go.mod h1:H71+9G0Jr46Qs0BA3z3/xt0h9lbnJnCEYcaCJCWFBf0=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240919102704-a035b4a92e77 h1:Y3vswUk/rnCpkZzWBk+Mlr9LtMg6EI5LkQ4GvgHCslI=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20240919102704-a035b4a92e77/go.mod h1:H71+9G0Jr46Qs0BA3z3/xt0h9lbnJnCEYcaCJCWFBf0=
 github.com/deckhouse/sds-node-configurator/api v0.0.0-20240925090458-249de2896583 h1:HQd5YFQqoHj/CQwBKFCyuVCQmNV0PdML8QJiyDka4fQ=
 github.com/deckhouse/sds-node-configurator/api v0.0.0-20240925090458-249de2896583/go.mod h1:H71+9G0Jr46Qs0BA3z3/xt0h9lbnJnCEYcaCJCWFBf0=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=


### PR DESCRIPTION
## Description
### Changes Introduced

1. **Add Finalizers to StorageClass**:
    - Automatically add finalizers to `StorageClass` entities with the provisioner `replicated.csi.storage.deckhouse.io` when they are created. This ensures that these `StorageClass` objects cannot be deleted by users directly.

2. **Check Finalizers on Delete**:
    - Implement checks for finalizers when a `StorageClass` is requested to be deleted. This will prevent the deletion of `StorageClass` entities with the specified provisioner until the finalizers are properly handled.

3. **Fix Tests**:
    - Update existing tests and add new tests to cover the changes related to adding and checking finalizers on `StorageClass`.


## Why do we need it, and what problem does it solve?
During the migration from the internal module linstor to sds-replicated-volume, we decided to allow users to delete StorageClass. After the migration is complete, we need to prevent users from deleting StorageClass with the provisioner replicated.csi.storage.deckhouse.io and add finalizers to such StorageClass.

## What is the expected result?
Prevent users from deleting StorageClass with the provisioner replicated.csi.storage.deckhouse.io

## Changelog entries
```
section: controller
type: feature
summary: Add finalizers to StorageClass to prevent deletion
impact: Users will no longer be able to delete StorageClass objects with the provisioner "replicated.csi.storage.deckhouse.io" directly. This ensures that these objects are properly handled before deletion.
impact_level: default
```
