### PR TITLE
[monitoring] Fix alerts for LinstorSchedulerAdmission pods

### DIFF
--- a/monitoring/prometheus-rules/linstor-scheduler-admission.tpl
+++ b/monitoring/prometheus-rules/linstor-scheduler-admission.tpl
@@ -1,3 +1,4 @@
+{{- if (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
 - name: kubernetes.linstor.scheduler_state
   rules:
     - alert: D8LinstorSchedulerAdmissionPodIsNotReady
@@ -34,3 +35,6 @@
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-sds-replicated-volume describe deploy linstor-scheduler-admission`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-sds-replicated-volume describe pod -l app=linstor-scheduler-admission`
+{{- else }}
+[]
+{{- end }}

--- a/monitoring/prometheus-rules/linstor-scheduler-admission.tpl
+++ b/monitoring/prometheus-rules/linstor-scheduler-admission.tpl
@@ -1,4 +1,4 @@
-{{- if (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
+{{- if and (ne "dev" .Values.global.deckhouseVersion) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
 - name: kubernetes.linstor.scheduler_state
   rules:
     - alert: D8LinstorSchedulerAdmissionPodIsNotReady

--- a/monitoring/prometheus-rules/linstor-scheduler-admission.tpl
+++ b/monitoring/prometheus-rules/linstor-scheduler-admission.tpl
@@ -35,6 +35,4 @@
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-sds-replicated-volume describe deploy linstor-scheduler-admission`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-sds-replicated-volume describe pod -l app=linstor-scheduler-admission`
-{{- else }}
-[]
 {{- end }}


### PR DESCRIPTION
## Description
`linstor-scheduler-admission` does not used (and running) anymore in Deckhouse >= 1.64. 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Remove prometheus alerts from Deckhouse >= 1.64 related to `linstor-scheduler-admission` pods.
This is a fix for PR #185.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
