### PR TITLE
dev in tag fix

### DIFF
--- a/templates/linstor-scheduler/deployment.yaml
+++ b/templates/linstor-scheduler/deployment.yaml
@@ -167,7 +167,7 @@ spec:
               {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
               {{- include "linstor_scheduler_extender_resources" . | nindent 14 }}
               {{- end }}
-          {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
+          {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
           ports:
            - containerPort: 8099
              protocol: TCP

--- a/templates/linstor-scheduler/kube-scheduler-webhook-configuration.yaml
+++ b/templates/linstor-scheduler/kube-scheduler-webhook-configuration.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
+{{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
 apiVersion: deckhouse.io/v1alpha1
 kind: KubeSchedulerWebhookConfiguration
 metadata:

--- a/templates/linstor-scheduler/service.yaml
+++ b/templates/linstor-scheduler/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
+{{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -45,7 +45,7 @@ spec:
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
     MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsReplicatedVolume.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
-    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
+    {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registry.scheme }}"
     {{- else }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registryScheme }}"
@@ -56,7 +56,7 @@ spec:
 
     is_master=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname)" -o json | jq -c '.metadata.labels | contains({"node-role.kubernetes.io/control-plane": ""})')
     if [ $is_master == "true" ]; then
-      {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+      {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
       bb-package-module-install "serviceScripts:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.serviceScripts }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
       {{- else }}
       bb-rp-from-module-image-install "serviceScripts:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.serviceScripts }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
@@ -115,7 +115,7 @@ spec:
         rmmod drbd || true
       fi
 
-      {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+      {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
       bb-package-module-install "semver:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.semver }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
       {{- else }}
       bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.semver }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
@@ -144,7 +144,7 @@ spec:
       exit 0
     fi
 
-    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+    {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
     bb-package-module-install "drbd:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.drbd }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
     {{- else }}
     bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.drbd }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"

--- a/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -45,7 +45,7 @@ spec:
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
     MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsReplicatedVolume.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
-    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
+    {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registry.scheme }}"
     {{- else }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registryScheme }}"
@@ -56,7 +56,7 @@ spec:
 
     is_master=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname)" -o json | jq -c '.metadata.labels | contains({"node-role.kubernetes.io/control-plane": ""})')
     if [ $is_master == "true" ]; then
-      {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+      {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
       bb-package-module-install "serviceScripts:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.serviceScripts }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
       {{- else }}
       bb-rp-from-module-image-install "serviceScripts:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.serviceScripts }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
@@ -119,7 +119,7 @@ spec:
         rmmod drbd || true
       fi
 
-      {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+      {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
       bb-package-module-install "semver:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.semver }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
       {{- else }}
       bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.semver }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
@@ -147,7 +147,7 @@ spec:
       exit 0
     fi
 
-    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+    {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
     bb-package-module-install "drbd:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.drbd }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
     {{- else }}
     bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.drbd }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -45,7 +45,7 @@ spec:
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
     MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsReplicatedVolume.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
-    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
+    {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.58" .Values.global.deckhouseVersion) }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registry.scheme }}"
     {{- else }}
     MODULE_SCHEME="{{ .Values.sdsReplicatedVolume.registryScheme }}"
@@ -56,7 +56,7 @@ spec:
 
     is_master=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname)" -o json | jq -c '.metadata.labels | contains({"node-role.kubernetes.io/control-plane": ""})')
     if [ $is_master == "true" ]; then
-      {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+      {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
       bb-package-module-install "serviceScripts:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.serviceScripts }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
       {{- else }}
       bb-rp-from-module-image-install "serviceScripts:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.serviceScripts }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
@@ -116,7 +116,7 @@ spec:
         rmmod drbd || true
       fi
 
-      {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+      {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
       bb-package-module-install "semver:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.semver }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
       {{- else }}
       bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.semver }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
@@ -146,7 +146,7 @@ spec:
       exit 0
     fi
 
-    {{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+    {{- if or (hasPrefix "dev" .Values.global.deckhouseVersion) (hasSuffix "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
     bb-package-module-install "drbd:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.drbd }}" "$MODULE_REPOSITORY" "sds-replicated-volume"
     {{- else }}
     bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsReplicatedVolume.drbd }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"


### PR DESCRIPTION
## Description

Fix for module templates of sds-replicated-volume


## Why do we need it, and what problem does it solve?

Fixed the following error during deploy of Deckhouse with `dev-v1.67-istio-extrafix` tag:

```
ModuleRun failed in phase 'CanRunHelm'. Requeue task to retry after delay. Failed count is 8. Error: template: sds-replicated-volume/templates/nodegroupconfiguration-drbd-install-debian-like.yaml:48:58: executing "sds-replicated-volume/templates/nodegroupconfiguration-drbd-install-debian-like.yaml" at <semverCompare ">=1.58" .Values.global.deckhouseVersion>: error calling semverCompare: Invalid Semantic Version
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
