### PR TITLE
[controller] Bug fix quorum on controller restart

### DIFF
--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
@@ -668,7 +668,7 @@ func setQuorumIfNeeded(ctx context.Context, log logger.Logger, lc *lapi.Client, 
 		rdPropQuorum == "off" {
 		log.Info(fmt.Sprintf("[setQuorumIfNeeded] Resource Definition %s quorum value will be set to 'majority'", rd.Name))
 
-		err = lc.ResourceDefinitions.Modify(ctx, rd.Name, lapi.GenericPropsModify{
+		err := lc.ResourceDefinitions.Modify(ctx, rd.Name, lapi.GenericPropsModify{
 			OverrideProps: map[string]string{
 				quorumWithPrefixRDKey: "majority",
 			},

--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
@@ -43,7 +43,7 @@ const (
 	PVCSIDriver                             = "replicated.csi.storage.deckhouse.io"
 	replicasOnSameRGKey                     = "replicas_on_same"
 	replicasOnDifferentRGKey                = "replicas_on_different"
-	SCCSIProvisioner                        = "replicated.csi.storage.deckhouse.io"
+	ReplicatedCSIProvisioner                = "replicated.csi.storage.deckhouse.io"
 	quorumWithPrefixRDKey                   = "DrbdOptions/Resource/quorum"
 	quorumMinimumRedundancyWithoutPrefixKey = "quorum-minimum-redundancy"
 	quorumMinimumRedundancyWithPrefixRGKey  = "DrbdOptions/Resource/quorum-minimum-redundancy"
@@ -663,9 +663,9 @@ func setLabelsIfNeeded(
 
 func setQuorumIfNeeded(ctx context.Context, log logger.Logger, lc *lapi.Client, sc v1.StorageClass, rd lapi.ResourceDefinitionWithVolumeDefinition) {
 	rdPropQuorum := rd.Props[quorumWithPrefixRDKey]
-	if sc.Provisioner == SCCSIProvisioner &&
+	if sc.Provisioner == ReplicatedCSIProvisioner &&
 		sc.Parameters[StorageClassPlacementCountKey] != "1" &&
-		rdPropQuorum == "off" {
+		slices.Contains([]string{"off", "1", ""}, rdPropQuorum) {
 		log.Info(fmt.Sprintf("[setQuorumIfNeeded] Resource Definition %s quorum value will be set to 'majority'", rd.Name))
 
 		err := lc.ResourceDefinitions.Modify(ctx, rd.Name, lapi.GenericPropsModify{

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -94,7 +94,6 @@ const (
 	SuspendIo                                      = "suspend-io"
 	StorageClassParamAutoAddQuorumTieBreakerKey    = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/auto-add-quorum-tiebreaker"
 	StorageClassParamOnNoQuorumKey                 = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/on-no-quorum"
-	StorageClassParamQuorumKey                     = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/quorum"
 	StorageClassParamOnNoDataAccessibleKey         = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/on-no-data-accessible"
 	StorageClassParamOnSuspendedPrimaryOutdatedKey = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/on-suspended-primary-outdated"
 	PrimaryOutdatedForceSecondary                  = "force-secondary"
@@ -477,7 +476,6 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *srv.Replicated
 		StorageClassParamOnNoQuorumKey:                 SuspendIo,
 		StorageClassParamOnNoDataAccessibleKey:         SuspendIo,
 		StorageClassParamOnSuspendedPrimaryOutdatedKey: PrimaryOutdatedForceSecondary,
-		StorageClassParamQuorumKey:                     "", // Make empty by default then we are going to track this field and set to `majority`
 	}
 
 	switch replicatedSC.Spec.Replication {

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -94,6 +94,7 @@ const (
 	SuspendIo                                      = "suspend-io"
 	StorageClassParamAutoAddQuorumTieBreakerKey    = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/auto-add-quorum-tiebreaker"
 	StorageClassParamOnNoQuorumKey                 = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/on-no-quorum"
+	StorageClassParamQuorumKey                     = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/quorum"
 	StorageClassParamOnNoDataAccessibleKey         = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/on-no-data-accessible"
 	StorageClassParamOnSuspendedPrimaryOutdatedKey = "property.replicated.csi.storage.deckhouse.io/DrbdOptions/Resource/on-suspended-primary-outdated"
 	PrimaryOutdatedForceSecondary                  = "force-secondary"
@@ -476,6 +477,7 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *srv.Replicated
 		StorageClassParamOnNoQuorumKey:                 SuspendIo,
 		StorageClassParamOnNoDataAccessibleKey:         SuspendIo,
 		StorageClassParamOnSuspendedPrimaryOutdatedKey: PrimaryOutdatedForceSecondary,
+		StorageClassParamQuorumKey:                     "", // Make empty by default then we are going to track this field and set to `majority`
 	}
 
 	switch replicatedSC.Spec.Replication {


### PR DESCRIPTION
## Problem
Linstor Resource Definition property 'DrbdOptions/Resource/quorum' set to 'off' on restart

## Description
sds-replicated-volume-controller watcher check property and set to 'majority' if needed

## Checklist
- [ ] Test manually on Kubernetes cluster
- [ ] The code is covered by unit tests