### PR TITLE
[controller] Fix RSC recreation

### DIFF
--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -644,7 +644,9 @@ func canRecreateStorageClass(newSC, oldSC *storagev1.StorageClass) (bool, string
 	// If other parameters are not equal, we can't recreate StorageClass and
 	// users must delete ReplicatedStorageClass resource and create it again manually.
 	delete(newSCCopy.Parameters, QuorumMinimumRedundancyWithPrefixSCKey)
+	delete(newSCCopy.Parameters, ReplicatedStorageClassParamNameKey)
 	delete(oldSCCopy.Parameters, QuorumMinimumRedundancyWithPrefixSCKey)
+	delete(oldSCCopy.Parameters, ReplicatedStorageClassParamNameKey)
 	return CompareStorageClasses(newSCCopy, oldSCCopy)
 }
 
@@ -671,7 +673,7 @@ func recreateStorageClassIfNeeded(
 		return false, false, err
 	}
 
-	log.Info("[recreateStorageClassIfNeeded] StorageClass can be recreated.")
+	log.Info("[recreateStorageClassIfNeeded] StorageClass will be recreated.")
 	if err := DeleteStorageClass(ctx, cl, oldSC); err != nil {
 		err = fmt.Errorf("[recreateStorageClassIfNeeded] error DeleteStorageClass: %w", err)
 		return false, true, err


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Because of changes in CSI, we need to add RSC parameter in StorageClasses. So our controller must handle with this.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct StorageClasses recreation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
