### PR TITLE
fix alert problem on manual certificate renewal

### DIFF
--- a/hooks/go/060-manual-cert-renewal/state_machine.go
+++ b/hooks/go/060-manual-cert-renewal/state_machine.go
@@ -28,11 +28,13 @@ const (
 	DaemonSetNameCsiNode = "linstor-csi-node"
 	DaemonSetNameNode    = "linstor-node"
 
-	DeploymentNameSchedulerExtender = "linstor-scheduler-extender"
-	DeploymentNameWebhooks          = "webhooks"
-	DeploymentNameSpaas             = "spaas"
-	DeploymentNameController        = "linstor-controller"
-	DeploymentNameCsiController     = "linstor-csi-controller"
+	DeploymentNameSchedulerExtender  = "linstor-scheduler-extender"
+	DeploymentNameWebhooks           = "webhooks"
+	DeploymentNameSpaas              = "spaas"
+	DeploymentNameController         = "linstor-controller"
+	DeploymentNameCsiController      = "linstor-csi-controller"
+	DeploymentNameAffinityController = "linstor-affinity-controller"
+	DeploymentNameSdsRVController    = "sds-replicated-volume-controller"
 
 	WaitForResourcesPollInterval = 2 * time.Second
 )
@@ -46,6 +48,8 @@ var (
 		DeploymentNameSpaas,
 		DeploymentNameController,
 		DeploymentNameCsiController,
+		DeploymentNameAffinityController,
+		DeploymentNameSdsRVController,
 	}
 )
 
@@ -275,6 +279,14 @@ func (s *stateMachine) turnOffAndRenewCerts() error {
 		return err
 	}
 
+	if err := s.turnOffDeploymentAndWait(DeploymentNameAffinityController); err != nil {
+		return err
+	}
+
+	if err := s.turnOffDeploymentAndWait(DeploymentNameSdsRVController); err != nil {
+		return err
+	}
+
 	if err := s.turnOffDeploymentAndWait(DeploymentNameCsiController); err != nil {
 		return err
 	}
@@ -401,6 +413,14 @@ func (s *stateMachine) turnOn() error {
 	}
 
 	if err := s.turnOnDeploymentAndWait(DeploymentNameCsiController); err != nil {
+		return err
+	}
+
+	if err := s.turnOnDeploymentAndWait(DeploymentNameAffinityController); err != nil {
+		return err
+	}
+
+	if err := s.turnOnDeploymentAndWait(DeploymentNameSdsRVController); err != nil {
 		return err
 	}
 

--- a/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/linstor_resources_watcher.go
@@ -241,11 +241,7 @@ func ReconcilePVReplicas(
 		rg := rgs[RGName]
 		log.Debug(fmt.Sprintf("[ReconcilePVReplicas] PV: %s, RG: %s", pv.Name, rg.Name))
 
-		resources, ok := res[pv.Name]
-		if !ok {
-			continue
-		}
-
+		resources := res[pv.Name]
 		replicasErrLevel, err := checkPVMinReplicasCount(ctx, log, lc, rg, resources)
 		if err != nil {
 			log.Error(err, "[ReconcilePVReplicas] unable to validate replicas count")
@@ -280,12 +276,11 @@ func checkPVMinReplicasCount(
 	resources []lapi.Resource,
 ) (string, error) {
 	placeCount := int(rg.SelectFilter.PlaceCount)
-	upVols := 0
-
 	if placeCount <= 0 {
 		return "", nil
 	}
 
+	upVols := 0
 	for _, r := range resources {
 		volList, err := lc.Resources.GetVolumes(ctx, r.Name, r.NodeName)
 		if err != nil {


### PR DESCRIPTION
## Description
Cert renewal state_machine updated to turn on/off linstor-affinity-controller and sds-replicated-volume-controller

## Why do we need it, and what problem does it solve?
Manually certificate renewal process deactivates PV (Persistent Volume) label 'storage.deckhouse.io/pv-not-enough-replicas' update

## What is the expected result?
After [manually certificate renewal process](https://deckhouse.io/products/kubernetes-platform/modules/sds-replicated-volume/stable/faq.html#how-to-manually-trigger-the-certificate-renewal-process) label will updated

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
