### PR TITLE
D8NodeHighUnknownMemoryUsage alert added

### DIFF
--- a/monitoring/prometheus-rules/memory-leak.yaml
+++ b/monitoring/prometheus-rules/memory-leak.yaml
@@ -2,7 +2,7 @@
   rules:
     - alert: D8NodeHighUnknownMemoryUsage
       expr: ((sum (
-          node_memory_MemTotal_bytes
+        node_memory_MemTotal_bytes
         - node_memory_MemFree_bytes
         - node_memory_AnonPages_bytes
         - node_memory_Mapped_bytes
@@ -26,3 +26,4 @@
         description: |
           Unaccounted memory usage is too high on node {{ $labels.node }}.
           This may indicate a memory leak in the system or a misconfiguration.
+          Please contact with tech support to investigate the issue.

--- a/monitoring/prometheus-rules/memory-leak.yaml
+++ b/monitoring/prometheus-rules/memory-leak.yaml
@@ -1,0 +1,28 @@
+- name: kubernetes.
+  rules:
+    - alert: D8NodeHighUnknownMemoryUsage
+      expr: ((sum (
+          node_memory_MemTotal_bytes
+        - node_memory_MemFree_bytes
+        - node_memory_AnonPages_bytes
+        - node_memory_Mapped_bytes
+        - node_memory_Buffers_bytes
+        - node_memory_SReclaimable_bytes
+        - clamp_min(node_memory_Cached_bytes - node_memory_Mapped_bytes, 0)
+        - node_memory_SUnreclaim_bytes
+        - node_memory_KernelStack_bytes
+        - node_memory_PageTables_bytes
+        ) by(node) / sum(node_memory_MemTotal_bytes) by(node)) * 100 ) > 25
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_node_high_unknown_memory_usage: "D8NodeHighUnknownMemoryUsage,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_node_high_unknown_memory_usage: "D8NodeHighUnknownMemoryUsage,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: "Unaccounted memory usage is too high on {{ $labels.node }}"
+        description: |
+          Unaccounted memory usage is too high on node {{ $labels.node }}.
+          This may indicate a memory leak in the system or a misconfiguration.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

D8NodeHighUnknownMemoryUsage alert added

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Added alert about high kernel memory usage (it may be caused by DRBD memory leak)
We need more data to investigate and fix it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
