### PR TITLE
[monitoring] Fix D8NodeHighUnknownMemoryUsage alert grouping

### DIFF
--- a/monitoring/prometheus-rules/memory-leak.yaml
+++ b/monitoring/prometheus-rules/memory-leak.yaml
@@ -20,8 +20,8 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_node_high_unknown_memory_usage: "D8NodeHighUnknownMemoryUsage,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_node_high_unknown_memory_usage: "D8NodeHighUnknownMemoryUsage,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_node_high_unknown_memory_usage: "D8PossibleMemoryProblems,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_node_high_unknown_memory_usage: "D8PossibleMemoryProblems,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: "Unaccounted memory usage is too high on {{ $labels.node }}"
         description: |
           Unaccounted memory usage is too high on node {{ $labels.node }}.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix alert grouping problem

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct memory alerting

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
