### PR TITLE
[internal] add kube-rbac-proxy liveness/readyness probes

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -22,13 +22,7 @@ linters-settings:
           container: node-driver-registrar
         - kind: DaemonSet
           name: linstor-node
-          container: kube-rbac-proxy
-        - kind: DaemonSet
-          name: linstor-node
           container: linstor-resources-cleaner
-        - kind: Deployment
-          name: linstor-controller
-          container: kube-rbac-proxy
         - kind: Deployment
           name: linstor-scheduler-extender
           container: linstor-scheduler-extender
@@ -62,16 +56,10 @@ linters-settings:
           container: linstor-resources-cleaner
         - kind: DaemonSet
           name: linstor-node
-          container: kube-rbac-proxy
-        - kind: DaemonSet
-          name: linstor-node
           container: linstor-satellite
         - kind: DaemonSet
           name: linstor-node
           container: drbd-prometheus-exporter
-        - kind: Deployment
-          name: linstor-controller
-          container: kube-rbac-proxy
         - kind: Deployment
           name: linstor-controller
           container: linstor-controller

--- a/templates/linstor-controller/deployment.yaml
+++ b/templates/linstor-controller/deployment.yaml
@@ -218,6 +218,16 @@ spec:
                     name: linstor-controller
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 3370
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 3370
+            scheme: HTTPS
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/templates/linstor-controller/deployment.yaml
+++ b/templates/linstor-controller/deployment.yaml
@@ -197,6 +197,7 @@ spec:
           - --v=2
           - --logtostderr=true
           - --stale-cache-interval=1h30m
+          - "--livez-path=/livez"
         env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:

--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -222,6 +222,16 @@ spec:
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 4215
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 4215
+            scheme: HTTPS
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -200,6 +200,7 @@ spec:
           - --v=2
           - --logtostderr=true
           - --stale-cache-interval=1h30m
+          - "--livez-path=/livez"
         env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add kube-rbac-proxy liveness/readyness probes

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct module templates

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
