### PR TITLE
[internal] add volumesnapshtoclassname annotation and csi-node name fix

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -18,7 +18,7 @@ linters-settings:
           name: csi-controller
           container: livenessprobe
         - kind: DaemonSet
-          name: sds-replicated-volume
+          name: csi-node
           container: node-driver-registrar
         - kind: DaemonSet
           name: linstor-node
@@ -46,10 +46,10 @@ linters-settings:
           name: csi-controller
           container: controller
         - kind: DaemonSet
-          name: sds-replicated-volume
+          name: csi-node
           container: node
         - kind: DaemonSet
-          name: sds-replicated-volume
+          name: csi-node
           container: node-driver-registrar
         - kind: DaemonSet
           name: linstor-node

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -106,9 +106,8 @@ const (
 	ManagedLabelKey   = "storage.deckhouse.io/managed-by"
 	ManagedLabelValue = "sds-replicated-volume"
 
-	RSCStorageClassVolumeSnapshotClassAnnotationKey = "storage.deckhouse.io/volumesnapshotclass"
+	RSCStorageClassVolumeSnapshotClassAnnotationKey   = "storage.deckhouse.io/volumesnapshotclass"
 	RSCStorageClassVolumeSnapshotClassAnnotationValue = "sds-replicated-volume"
-
 
 	Created = "Created"
 	Failed  = "Failed"

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class.go
@@ -106,6 +106,10 @@ const (
 	ManagedLabelKey   = "storage.deckhouse.io/managed-by"
 	ManagedLabelValue = "sds-replicated-volume"
 
+	RSCStorageClassVolumeSnapshotClassAnnotationKey = "storage.deckhouse.io/volumesnapshotclass"
+	RSCStorageClassVolumeSnapshotClassAnnotationValue = "sds-replicated-volume"
+
+
 	Created = "Created"
 	Failed  = "Failed"
 
@@ -538,7 +542,7 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *srv.Replicated
 			Finalizers:      []string{StorageClassFinalizerName},
 			ManagedFields:   nil,
 			Labels:          map[string]string{ManagedLabelKey: ManagedLabelValue},
-			Annotations:     nil,
+			Annotations:     map[string]string{RSCStorageClassVolumeSnapshotClassAnnotationKey: RSCStorageClassVolumeSnapshotClassAnnotationValue},
 		},
 		AllowVolumeExpansion: &allowVolumeExpansion,
 		Parameters:           storageClassParameters,

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1652,7 +1652,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).NotTo(BeNil())
-		Expect(len(storageClass.Annotations)).To(Equal(1))
+		Expect(len(storageClass.Annotations)).To(Equal(2))
 		Expect(storageClass.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
 		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -110,6 +110,9 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 					APIVersion: controller.StorageClassAPIVersion,
 				},
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue,
+					},
 					Name:            testName,
 					Namespace:       testNamespaceConst,
 					OwnerReferences: nil,
@@ -944,7 +947,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -996,7 +999,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1054,7 +1057,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1119,7 +1122,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1185,7 +1188,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 	})
 
 	It("ReconcileReplicatedStorageClass_already_exists_with_valid_config_VolumeAccessPreferablyLocal_ConfigMap_exist_with_virtualization_key_and_virtualization_value_updated_from_false_to_true", func() {
@@ -1230,7 +1233,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1296,7 +1299,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 	})
 
@@ -1344,6 +1347,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).NotTo(BeNil())
 		Expect(storageClass.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1409,7 +1413,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 	})
 
 	It("ReconcileReplicatedStorageClass_already_exists_with_valid_config_VolumeAccessPreferablyLocal_ConfigMap_exist_with_virtualization_key_and_virtualization_value_updated_from_true_to_false", func() {
@@ -1454,7 +1458,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1531,6 +1535,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).NotTo(BeNil())
 		Expect(storageClass.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 	})
 
 	It("ReconcileReplicatedStorageClass_already_exists_with_valid_config_VolumeAccessLocal_ConfigMap_exist_with_virtualization_key_and_virtualization_value_updated_from_true_to_false", func() {
@@ -1588,7 +1593,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(replicatedSC.Status.Phase).To(Equal(controller.Created))
 
 		storageClass = getAndValidateSC(ctx, cl, replicatedSC)
-		Expect(storageClass.Annotations).To(BeNil())
+		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1729,6 +1734,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(len(storageClass.Annotations)).To(Equal(2))
 		Expect(storageClass.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
 		Expect(storageClass.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		virtualizationEnabled, err := controller.GetVirtualizationModuleEnabled(ctx, cl, log, types.NamespacedName{Name: controller.ControllerConfigMapName, Namespace: validCFG.ControllerNamespace})
 		Expect(err).NotTo(HaveOccurred())

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1595,6 +1595,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		storageClass = getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)
@@ -1682,6 +1683,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(len(scResource.Annotations)).To(Equal(2))
 		Expect(scResource.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
 		Expect(scResource.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
+		Expect(scResource.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		shouldRequeue, err := controller.ReconcileReplicatedStorageClassEvent(ctx, cl, log, validCFG, request)
 		Expect(err).NotTo(HaveOccurred())

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1584,7 +1584,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		scResourceAfterUpdate := controller.GetNewStorageClass(&replicatedSC, virtualizationEnabled)
 		controller.DoUpdateStorageClass(scResourceAfterUpdate, storageClass)
 		Expect(scResourceAfterUpdate).NotTo(BeNil())
-		Expect(scResourceAfterUpdate.Annotations).To(BeNil())
+		Expect(scResourceAfterUpdate.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 
 		shouldRequeue, err := controller.ReconcileReplicatedStorageClassEvent(ctx, cl, log, validCFG, request)
 		Expect(err).NotTo(HaveOccurred())
@@ -1639,7 +1639,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		storageClassResource := controller.GetNewStorageClass(&replicatedSC, false)
 		Expect(storageClassResource).NotTo(BeNil())
-		Expect(storageClassResource.Annotations).To(BeNil())
+		Expect(storageClassResource.Annotations).To(Equal(map[string]string{controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}))
 		Expect(storageClassResource.Name).To(Equal(replicatedSC.Name))
 		Expect(storageClassResource.Namespace).To(Equal(replicatedSC.Namespace))
 		Expect(storageClassResource.Provisioner).To(Equal(controller.StorageClassProvisioner))
@@ -1715,7 +1715,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(configMap.Name).To(Equal(controller.ControllerConfigMapName))
 		Expect(configMap.Namespace).To(Equal(validCFG.ControllerNamespace))
 		Expect(configMap.Data).NotTo(BeNil())
-		Expect(configMap.Data[controller.VirtualizationModuleEnabledKey]).To(Equal("true"))
+		Expect(configMap.Data[controller.VirtualizationModuleEnabledKey]).To(Equal("false"))
 
 		configMap.Data[controller.VirtualizationModuleEnabledKey] = "false"
 		err = cl.Update(ctx, configMap)

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1736,7 +1736,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).NotTo(BeNil())
-		Expect(len(storageClass.Annotations)).To(Equal(2))
+		Expect(len(storageClass.Annotations)).To(Equal(3))
 		Expect(storageClass.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
 		Expect(storageClass.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
 		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1748,8 +1748,9 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		scResourceAfterUpdate := controller.GetNewStorageClass(&replicatedSC, virtualizationEnabled)
 		controller.DoUpdateStorageClass(scResourceAfterUpdate, storageClass)
 		Expect(scResourceAfterUpdate.Annotations).NotTo(BeNil())
-		Expect(len(scResourceAfterUpdate.Annotations)).To(Equal(1))
+		Expect(len(scResourceAfterUpdate.Annotations)).To(Equal(2))
 		Expect(scResourceAfterUpdate.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
+		Expect(scResourceAfterUpdate.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		shouldRequeue, err := controller.ReconcileReplicatedStorageClassEvent(ctx, cl, log, validCFG, request)
 		Expect(err).NotTo(HaveOccurred())

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1680,7 +1680,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		controller.DoUpdateStorageClass(scResource, storageClass)
 		Expect(scResource).NotTo(BeNil())
 		Expect(scResource.Annotations).NotTo(BeNil())
-		Expect(len(scResource.Annotations)).To(Equal(2))
+		Expect(len(scResource.Annotations)).To(Equal(3))
 		Expect(scResource.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
 		Expect(scResource.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
 		Expect(scResource.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
@@ -1694,9 +1694,10 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		storageClass = getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).NotTo(BeNil())
+		Expect(len(storageClass.Annotations)).To(Equal(3))
 		Expect(storageClass.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
-		Expect(len(storageClass.Annotations)).To(Equal(2))
 		Expect(storageClass.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 	})
 
 	It("ReconcileReplicatedStorageClass_already_exists_with_valid_config_VolumeAccessLocal_StorageClass_already_exists_with_default_and_vritualization_annotations_ConfigMap_exist_with_virtualization_key_and_virtualization_value_updated_from_true_to_false", func() {

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1761,8 +1761,9 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 
 		storageClass = getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).NotTo(BeNil())
-		Expect(len(storageClass.Annotations)).To(Equal(1))
+		Expect(len(storageClass.Annotations)).To(Equal(2))
 		Expect(storageClass.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		// Cleanup
 		err = cl.Delete(ctx, &replicatedSC)

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1579,6 +1579,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		storageClass := getAndValidateSC(ctx, cl, replicatedSC)
 		Expect(storageClass.Annotations).NotTo(BeNil())
 		Expect(storageClass.Annotations[controller.StorageClassVirtualizationAnnotationKey]).To(Equal(controller.StorageClassVirtualizationAnnotationValue))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		scResourceAfterUpdate := controller.GetNewStorageClass(&replicatedSC, virtualizationEnabled)
 		controller.DoUpdateStorageClass(scResourceAfterUpdate, storageClass)
@@ -1652,6 +1653,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(storageClass.Annotations).NotTo(BeNil())
 		Expect(len(storageClass.Annotations)).To(Equal(1))
 		Expect(storageClass.Annotations[controller.DefaultStorageClassAnnotationKey]).To(Equal("true"))
+		Expect(storageClass.Annotations[controller.RSCStorageClassVolumeSnapshotClassAnnotationKey]).To(Equal(controller.RSCStorageClassVolumeSnapshotClassAnnotationValue))
 
 		err = createConfigMap(ctx, cl, validCFG.ControllerNamespace, map[string]string{controller.VirtualizationModuleEnabledKey: "true"})
 		Expect(err).NotTo(HaveOccurred())

--- a/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
+++ b/images/sds-replicated-volume-controller/pkg/controller/replicated_storage_class_test.go
@@ -1645,7 +1645,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(storageClassResource.Provisioner).To(Equal(controller.StorageClassProvisioner))
 
 		// add default annotation
-		storageClassResource.Annotations = map[string]string{controller.DefaultStorageClassAnnotationKey: "true"}
+		storageClassResource.Annotations = map[string]string{controller.DefaultStorageClassAnnotationKey: "true", controller.RSCStorageClassVolumeSnapshotClassAnnotationKey: controller.RSCStorageClassVolumeSnapshotClassAnnotationValue}
 
 		err := cl.Create(ctx, storageClassResource)
 		Expect(err).NotTo(HaveOccurred())
@@ -1715,7 +1715,7 @@ var _ = Describe(controller.ReplicatedStorageClassControllerName, func() {
 		Expect(configMap.Name).To(Equal(controller.ControllerConfigMapName))
 		Expect(configMap.Namespace).To(Equal(validCFG.ControllerNamespace))
 		Expect(configMap.Data).NotTo(BeNil())
-		Expect(configMap.Data[controller.VirtualizationModuleEnabledKey]).To(Equal("false"))
+		Expect(configMap.Data[controller.VirtualizationModuleEnabledKey]).To(Equal("true"))
 
 		configMap.Data[controller.VirtualizationModuleEnabledKey] = "false"
 		err = cl.Update(ctx, configMap)

--- a/templates/csi/controller.yaml
+++ b/templates/csi/controller.yaml
@@ -185,7 +185,6 @@ storage.deckhouse.io/sds-replicated-volume-node: ""
 {{- $csiNodeImage := include "helm_lib_module_image" (list . "linstorCsi") }}
 
 {{- $csiNodeConfig := dict }}
-{{- $_ := set $csiNodeConfig "fullname" "sds-replicated-volume" }}
 {{- $_ := set $csiNodeConfig "nodeImage" $csiNodeImage }}
 {{- $_ := set $csiNodeConfig "driverFQDN" "replicated.csi.storage.deckhouse.io" }}
 {{- $_ := set $csiNodeConfig "livenessProbePort" 4262 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add volumesnapshtoclassname annotation and csi-node name fix

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct volume snapshot work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
