### PR TITLE
[monitoring] fix D8NodeHighUnknownMemoryUsage alert's expression

### DIFF
--- a/monitoring/prometheus-rules/memory-leak.yaml
+++ b/monitoring/prometheus-rules/memory-leak.yaml
@@ -1,18 +1,22 @@
 - name: kubernetes.
   rules:
     - alert: D8NodeHighUnknownMemoryUsage
-      expr: ((sum (
-        node_memory_MemTotal_bytes
-        - node_memory_MemFree_bytes
-        - node_memory_AnonPages_bytes
-        - node_memory_Mapped_bytes
-        - node_memory_Buffers_bytes
-        - node_memory_SReclaimable_bytes
-        - clamp_min(node_memory_Cached_bytes - node_memory_Mapped_bytes, 0)
-        - node_memory_SUnreclaim_bytes
-        - node_memory_KernelStack_bytes
-        - node_memory_PageTables_bytes
-        ) by(node) / sum(node_memory_MemTotal_bytes) by(node)) * 100 ) > 25
+      expr: (
+        sum(
+          node_memory_MemTotal_bytes{node!=""}
+          - node_memory_MemFree_bytes{node!=""}
+          - node_memory_AnonPages_bytes{node!=""}
+          - node_memory_Mapped_bytes{node!=""}
+          - node_memory_Buffers_bytes{node!=""}
+          - node_memory_SReclaimable_bytes{node!=""}
+          - clamp_min(node_memory_Cached_bytes{node!=""} - node_memory_Mapped_bytes{node!=""}, 0)
+          - node_memory_SUnreclaim_bytes{node!=""}
+          - node_memory_KernelStack_bytes{node!=""}
+          - node_memory_PageTables_bytes{node!=""}
+        ) by (node)
+        /
+        sum(node_memory_MemTotal_bytes{node!=""}) by (node)
+        ) * 100 > 25
       for: 5m
       labels:
         severity_level: "4"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix D8NodeHighUnknownMemoryUsage alert's expression

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct monitoring

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
