### PR TITLE
[internal] add sys fs cgroup mount

### DIFF
--- a/templates/linstor-node/daemonset.yaml
+++ b/templates/linstor-node/daemonset.yaml
@@ -173,6 +173,8 @@ spec:
             name: device-dir
           - mountPath: /sys/
             name: sys-dir
+          - mountPath: /sys/fs/cgroup
+            name: sys-fs-cgroup-dir
           - mountPath: /lib/modules/
             mountPropagation: Bidirectional
             name: modules-dir
@@ -307,6 +309,9 @@ spec:
             path: /sys/
             type: Directory
           name: sys-dir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: sys-fs-cgroup-dir
         - hostPath:
             path: /lib/modules/
             type: DirectoryOrCreate

--- a/templates/sds-replicated-volume-controller/deployment.yaml
+++ b/templates/sds-replicated-volume-controller/deployment.yaml
@@ -135,6 +135,8 @@ spec:
               mountPath: /dev/
             - name: host-sys-dir
               mountPath: /sys/
+            - name: host-sys-fs-cgroup
+              mountPath: /sys/fs/cgroup
             - name: host-root
               mountPath: /host-root/
               mountPropagation: HostToContainer
@@ -147,6 +149,9 @@ spec:
           hostPath:
             path: /sys/
             type: Directory
+        - name: host-sys-fs-cgroup
+          hostPath:
+            path: /sys/fs/cgroup
         - name: host-root
           hostPath:
             path: /


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add /sys/fs/cgroup mount for containerd v2 support

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Containerd v2 support for module

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
