### PR TITLE
[agent] Add sync percent

### DIFF
--- a/api/v1alpha1/replicated_volume_replica.go
+++ b/api/v1alpha1/replicated_volume_replica.go
@@ -41,7 +41,7 @@ import (
 // +kubebuilder:printcolumn:name="Configured",type=string,JSONPath=".status.conditions[?(@.type=='Configured')].status"
 // +kubebuilder:printcolumn:name="DataInitialized",type=string,JSONPath=".status.conditions[?(@.type=='DataInitialized')].status"
 // +kubebuilder:printcolumn:name="InQuorum",type=string,JSONPath=".status.conditions[?(@.type=='InQuorum')].status"
-// +kubebuilder:printcolumn:name="InSync",type=string,JSONPath=".status.conditions[?(@.type=='InSync')].status"
+// +kubebuilder:printcolumn:name="InSync",type=string,JSONPath=".status.syncProgress"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 type ReplicatedVolumeReplica struct {
 	metav1.TypeMeta `json:",inline"`
@@ -126,6 +126,13 @@ type ReplicatedVolumeReplicaStatus struct {
 
 	// +patchStrategy=merge
 	DRBD *DRBD `json:"drbd,omitempty" patchStrategy:"merge"`
+
+	// SyncProgress shows sync status for kubectl output:
+	// - "True" when fully synced (InSync condition is True)
+	// - "XX.XX%" during active synchronization (SyncTarget)
+	// - DiskState (e.g. "Outdated", "Inconsistent") when not syncing but not in sync
+	// +optional
+	SyncProgress string `json:"syncProgress,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/crds/storage.deckhouse.io_replicatedvolumereplicas.yaml
+++ b/crds/storage.deckhouse.io_replicatedvolumereplicas.yaml
@@ -46,7 +46,7 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='InQuorum')].status
       name: InQuorum
       type: string
-    - jsonPath: .status.conditions[?(@.type=='InSync')].status
+    - jsonPath: .status.syncProgress
       name: InSync
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -481,6 +481,13 @@ spec:
                 type: object
               lvmLogicalVolumeName:
                 maxLength: 256
+                type: string
+              syncProgress:
+                description: |-
+                  SyncProgress shows sync status for kubectl output:
+                  - "True" when fully synced (InSync condition is True)
+                  - "XX.XX%" during active synchronization (SyncTarget)
+                  - DiskState (e.g. "Outdated", "Inconsistent") when not syncing but not in sync
                 type: string
             type: object
         required:


### PR DESCRIPTION
## Description

Add sync progress percentage display in RVR's InSync column. During synchronization, shows actual percentage instead of just "False".

Changes:
- Add `syncProgress` field to RVR status
- Update InSync printer column to show syncProgress
- Implement progress calculation in agent scanner

No restarts of critical components required. Changes affect only kubectl display output.

## Why do we need it, and what problem does it solve?

Currently, during replica synchronization the InSync column shows only "False", providing no visibility into sync progress. Users have to check DRBD status manually to see how long sync will take.

This change allows operators to quickly see sync progress (e.g. "42.50%") directly in `kubectl get rvr` output, improving operational visibility.

## What is the expected result?

After applying, `kubectl get rvr` shows sync progress:
```
NAME    VOLUME   NODE    TYPE      INSYNC     AGE
rvr-1   vol-1    node1   Diskful   True       5m
rvr-2   vol-1    node2   Diskful   42.50%     2m   # syncing
rvr-3   vol-1    node3   Diskful   Outdated   1m   # waitingInSync column values:
```

- `True` — fully synchronized
- `XX.XX%` — sync in progress
- `Unknown` — status not yet available
- DiskState (e.g. `Outdated`) — not syncing, waiting for resync

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
