### PR TITLE
[controller] Change to llv.spec.actualLVNameOnTheNode == rvrName

### DIFF
--- a/images/controller/internal/controllers/rvr_volume/reconciler.go
+++ b/images/controller/internal/controllers/rvr_volume/reconciler.go
@@ -261,7 +261,7 @@ func createLLV(ctx context.Context, cl client.Client, scheme *runtime.Scheme, rv
 			Name: rvr.Name,
 		},
 		Spec: snc.LVMLogicalVolumeSpec{
-			ActualLVNameOnTheNode: rvr.Spec.ReplicatedVolumeName,
+			ActualLVNameOnTheNode: rvr.Name,
 			LVMVolumeGroupName:    lvmVolumeGroupName,
 			Size:                  rv.Spec.Size.String(),
 		},

--- a/images/controller/internal/controllers/rvr_volume/reconciler_test.go
+++ b/images/controller/internal/controllers/rvr_volume/reconciler_test.go
@@ -541,7 +541,7 @@ var _ = Describe("Reconciler", func() {
 						Expect(llv.Spec.LVMVolumeGroupName).To(Equal("test-lvg"))
 						Expect(llv.Spec.Size).To(Equal("1Gi"))
 						Expect(llv.Spec.Type).To(Equal("Thick"))
-						Expect(llv.Spec.ActualLVNameOnTheNode).To(Equal("test-rv"))
+						Expect(llv.Spec.ActualLVNameOnTheNode).To(Equal(rvr.Name))
 
 						Expect(cl.Get(ctx, client.ObjectKeyFromObject(rvr), rvr)).To(Succeed())
 						Expect(rvr).To(HaveNoLVMLogicalVolumeName())
@@ -568,7 +568,7 @@ var _ = Describe("Reconciler", func() {
 							Expect(llv.Spec.LVMVolumeGroupName).To(Equal("test-lvg"))
 							Expect(llv.Spec.Size).To(Equal("1Gi"))
 							Expect(llv.Spec.Type).To(Equal("Thick"))
-							Expect(llv.Spec.ActualLVNameOnTheNode).To(Equal("test-rv"))
+							Expect(llv.Spec.ActualLVNameOnTheNode).To(Equal(rvr.Name))
 
 							Expect(cl.Get(ctx, client.ObjectKeyFromObject(rvr), rvr)).To(Succeed())
 							Expect(rvr).To(HaveNoLVMLogicalVolumeName())
@@ -748,9 +748,11 @@ var _ = Describe("Reconciler", func() {
 							Expect(llvList.Items).To(HaveLen(1))
 
 							llv := &llvList.Items[0]
+							Expect(llv.Name).To(Equal(rvr.Name))
 							Expect(llv.Spec.Type).To(Equal("Thin"))
 							Expect(llv.Spec.Thin).NotTo(BeNil())
 							Expect(llv.Spec.Thin.PoolName).To(Equal("test-thin-pool"))
+							Expect(llv.Spec.ActualLVNameOnTheNode).To(Equal(rvr.Name))
 						})
 					})
 				})
@@ -1130,6 +1132,7 @@ var _ = Describe("Reconciler", func() {
 			Expect(llvList.Items).To(HaveLen(1))
 			llvName := llvList.Items[0].Name
 			Expect(llvName).To(Equal(rvr.Name))
+			Expect(llvList.Items[0].Spec.ActualLVNameOnTheNode).To(Equal(rvr.Name))
 
 			// Verify condition is set to NotReady after LLV creation
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(rvr), rvr)).To(Succeed())
@@ -1217,6 +1220,7 @@ var _ = Describe("Reconciler", func() {
 			Expect(cl.List(ctx, &llvList)).To(Succeed())
 			Expect(llvList.Items).To(HaveLen(1))
 			Expect(llvList.Items[0].Name).To(Equal(rvr.Name))
+			Expect(llvList.Items[0].Spec.ActualLVNameOnTheNode).To(Equal(rvr.Name))
 		})
 	})
 })


### PR DESCRIPTION
## Description
Fixed the `ActualLVNameOnTheNode` field in `LVMLogicalVolume` to use the RVR name instead of the ReplicatedVolume name when creating LLV resources. Updated unit tests to verify that the created LLV has the correct name and `ActualLVNameOnTheNode` value matching the RVR name.

## Why do we need it, and what problem does it solve?
The `ActualLVNameOnTheNode` field in `LVMLogicalVolume` was incorrectly set to `rvr.Spec.ReplicatedVolumeName` instead of `rvr.Name`. 

## What is the expected result?
The `ActualLVNameOnTheNode` field in created `LVMLogicalVolume` resources MUST be set to the RVR name (not the ReplicatedVolume name)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
