### PR TITLE
[rules] Add kubebuilder markers rule for gofmt smart quotes issue

### DIFF
--- a/.cursor/rules/api-kubebuilder-markers.mdc
+++ b/.cursor/rules/api-kubebuilder-markers.mdc
@@ -1,7 +1,7 @@
 ---
 description: Kubebuilder marker hygiene rules for CEL expressions, gofmt smart quote avoidance, and typographic character detection. Apply when writing or editing kubebuilder markers (especially XValidation with CEL), when reviewing API types under api/v*/, and when debugging unexpected character transformations in comments. Apply when editing relevant files, and when reasoning/planning/answering questions where this rule could influence code decisions (even if matching files are not currently open).
 globs: api/v*/**/*.go
-alwaysApply: false
+alwaysApply: true
 ---
 
 Normative keywords used in this document are defined in `rfc-like-mdc.mdc`.


### PR DESCRIPTION
## Description

Add Cursor rule documenting `gofmt` smart quote issue in kubebuilder CEL expressions.

## Why do we need it, and what problem does it solve?

`gofmt` (Go 1.19+) converts `''` → `"` (U+201D) in doc comments, breaking CEL validation rules like `field != ''`. This causes silent CRD failures that are hard to debug.

**Ref:** https://stackoverflow.com/questions/79734115

Rule documents the workaround: use `size(field) > 0` instead of `field != ''`.

## What is the expected result?

Developers and AI assistants will avoid using `''` in CEL expressions, preventing typographic quote corruption by `gofmt`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
