### PR TITLE
[agent] Add dmsetup utility to agent image

### DIFF
--- a/.werf/consts.yaml
+++ b/.werf/consts.yaml
@@ -37,6 +37,7 @@
 {{- $_ := set $versions "SEMVER_TOOL" "3.4.0" }}
 {{- $_ := set $versions "SPAAS" "v0.1.5" }}
 {{- $_ := set $versions "THIN_SEND_RECV" "1.1.3" }}
+{{- $_ := set $versions "LVM2" "2_03_38" }}
 
 {{- $_ := set $ "VERSIONS" $versions }}
 

--- a/images/agent/werf.inc.yaml
+++ b/images/agent/werf.inc.yaml
@@ -21,9 +21,13 @@ shell:
     - cd /src/drbd-utils
     - git submodule update --init --recursive
     #- rm -rf /src/drbd-utils/.git # needed for make
+    # LVM2
+    - git clone --depth 1 --branch v{{ $.Versions.LVM2 }} {{ $.Root.SOURCE_REPO }}/lvmteam/lvm2.git /src/lvm2
+    - rm -rf /src/lvm2/.git
+
 
 ---
-{{- $drbdBinaries := "/drbd-utils/sbin/* /drbd-utils/etc/drbd.conf /drbd-utils/etc/drbd.d/global_common.conf /drbd-utils/etc/multipath/conf.d/drbd.conf" }}
+{{- $drbdBinaries := "/drbd-utils/sbin/* /drbd-utils/etc/drbd.conf /drbd-utils/etc/drbd.d/global_common.conf /drbd-utils/etc/multipath/conf.d/drbd.conf /usr/sbin/dmsetup /usr/sbin/dmstats" }}
 image: {{ .ImageName }}-binaries-artifact
 fromImage: builder/alt
 final: false
@@ -33,6 +37,7 @@ import:
     to: /src
     includePaths:
       - drbd-utils
+      - lvm2
     before: install
 git:
   - add: /tools/dev_images/additional_tools/alt/binary_replace.sh
@@ -57,6 +62,11 @@ shell:
     - make
     - make install DESTDIR=/drbd-utils
     - sed -i 's/usage-count\s*yes;/usage-count no;/' /drbd-utils/etc/drbd.d/global_common.conf
+    # LVM2 - Let's take only dmsetup
+    - cd /src/lvm2
+    - ./configure --prefix=/ --libdir=/lib64 --build=x86_64-linux-gnu --disable-readline --without-systemd
+    - make libdm.device-mapper
+    - make -C libdm install_device-mapper
   beforeSetup:
     - chmod +x /binary_replace.sh
     - /binary_replace.sh -i "{{ $drbdBinaries }}" -o /relocate


### PR DESCRIPTION
## Description
Add `dmsetup` utility from LVM2 to the agent image. The utility is built from LVM2 v2.03.38 source code, including only the device-mapper component (`libdm.device-mapper`) without documentation and other LVM2 components. Both `dmsetup` and `dmstats` binaries are included in the agent image binaries artifact.

## Why do we need it, and what problem does it solve?
The `dmsetup` utility is required for managing device-mapper devices in the agent. It provides essential functionality for interacting with device-mapper targets, which is needed for DRBD resource management operations.

## What is the expected result?
After applying these changes, the agent image will contain `dmsetup` and `dmstats` binaries in `/usr/sbin/`. The binaries should be available in the agent container and can be used for device-mapper operations.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
