### PR TITLE
[internal] update drbd to 9.2.16

### DIFF
--- a/openapi/values_ce.yaml
+++ b/openapi/values_ce.yaml
@@ -15,7 +15,7 @@ properties:
     properties:
       drbdVersion:
         type: string
-        default: "9.2.13"
+        default: "9.2.16"
       dataNodesChecksum:
         type: string
         default: "default_data_nodes_checksum"

--- a/openapi/values_ee.yaml
+++ b/openapi/values_ee.yaml
@@ -15,7 +15,7 @@ properties:
     properties:
       drbdVersion:
         type: string
-        default: "9.2.13"
+        default: "9.2.16"
       dataNodesChecksum:
         type: string
         default: "default_data_nodes_checksum"

--- a/oss.yaml
+++ b/oss.yaml
@@ -6,7 +6,7 @@
   license: GPL-2.0
 
 - id: DRBD
-  version: "9.2.13"
+  version: "9.2.16"
   name: DRBD
   link: https://github.com/LINBIT/drbd
   description: DRBD, developed by LINBIT, provides networked RAID 1 functionality for GNU/Linux. It is designed for high availability clusters and software defined storage.


### PR DESCRIPTION
## Description

Bump bundled DRBD from `9.2.13` to `9.2.16` (LINBIT 9.2 stable line).

Files touched:
- `oss.yaml` — `DRBD: "9.2.13"` → `"9.2.16"` (single source of truth, consumed by `images/drbd/werf.inc.yaml` and others via the `get_oss_version_by_id` helper).
- `openapi/values_ce.yaml`, `openapi/values_ee.yaml` — `internal.drbdVersion.default: "9.2.13"` → `"9.2.16"`.

Notable upstream changes between 9.2.13 and 9.2.16 (see [LINBIT/drbd ChangeLog](https://github.com/LINBIT/drbd/blob/drbd-9.2.16/ChangeLog)):

- **9.2.14**: race between write requests and very short resyncs that could cause DRBD to fail to resync the racing write; `suspend-IO` now waits for pending writes to complete (usable for consistent snapshots on primary/secondary); buffer-page pool fixes; RDMA CM leak fixes; Linux 6.14 / 6.15 compatibility.
- **9.2.15**: fix for the regression introduced in 9.2.13 where a primary never finishes a resync with a newly added peer; online-resize metadata-write regression (introduced in 9.2.8) fixed; several RDMA transport fixes; Linux 6.16 / 6.17-rc5 compatibility.
- **9.2.16**: do not trigger the OOM-killer when allocating a too-big dirty bitmap during attach (fail the attach instead); fix for divide-by-zero when flapping between Ahead and resync; fix for excessive `P_PEERS_IN_SYNC` packets at end of resync that caused I/O latency spikes on >10 TB devices; Linux 6.17 / 6.18-rc6 compatibility.

## Why do we need it, and what problem does it solve?

- Picks up the **9.2.13 → 9.2.15 resync regression fix**, which is the most user-visible bug in the currently shipped DRBD: a primary could fail to ever finish a resync with a newly added peer.
- Picks up several data-integrity / stability fixes around resync, online resize, attach (OOM-killer), and the RDMA transport.
- Adds compatibility with Linux 6.14–6.18, broadening the set of node kernels we can run on without local patching.

## What is the expected result?

- DRBD images and node modules are built from the `drbd-9.2.16` upstream tag.
- `replicatedstoragecluster` / cluster status reports `drbdVersion: 9.2.16` (from the openapi default until overridden by the controller).
- Existing 9.2.13 clusters upgrade in place: kernel module + userspace versions advance one minor without on-disk metadata changes (same `proto` / `transport` API as 9.2.13–9.2.15).
- No changes to module API, CRDs, RBAC, or operator behavior.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
