### PR TITLE
[api] Shorten verbose ReplicatedStorageClass enum constant names

### DIFF
--- a/api/v1alpha1/rsc_types.go
+++ b/api/v1alpha1/rsc_types.go
@@ -229,12 +229,12 @@ type ReplicatedStorageClassTopology string
 
 // Topology values for [ReplicatedStorageClass] spec.topology field.
 const (
-	// RSCTopologyTransZonal means replicas should be placed across zones.
-	RSCTopologyTransZonal ReplicatedStorageClassTopology = "TransZonal"
-	// RSCTopologyZonal means replicas should be placed in a single zone.
-	RSCTopologyZonal ReplicatedStorageClassTopology = "Zonal"
-	// RSCTopologyIgnored means topology information is not used for placement.
-	RSCTopologyIgnored ReplicatedStorageClassTopology = "Ignored"
+	// TopologyTransZonal means replicas should be placed across zones.
+	TopologyTransZonal ReplicatedStorageClassTopology = "TransZonal"
+	// TopologyZonal means replicas should be placed in a single zone.
+	TopologyZonal ReplicatedStorageClassTopology = "Zonal"
+	// TopologyIgnored means topology information is not used for placement.
+	TopologyIgnored ReplicatedStorageClassTopology = "Ignored"
 )
 
 func (t ReplicatedStorageClassTopology) String() string {
@@ -260,10 +260,10 @@ type ReplicatedStorageClassConfigurationRolloutStrategy struct {
 type ReplicatedStorageClassConfigurationRolloutStrategyType string
 
 const (
-	// ReplicatedStorageClassConfigurationRolloutStrategyTypeRollingUpdate means configuration changes are rolled out to existing volumes.
-	ReplicatedStorageClassConfigurationRolloutStrategyTypeRollingUpdate ReplicatedStorageClassConfigurationRolloutStrategyType = "RollingUpdate"
-	// ReplicatedStorageClassConfigurationRolloutStrategyTypeNewVolumesOnly means configuration changes only apply to newly created volumes.
-	ReplicatedStorageClassConfigurationRolloutStrategyTypeNewVolumesOnly ReplicatedStorageClassConfigurationRolloutStrategyType = "NewVolumesOnly"
+	// ConfigurationRolloutRollingUpdate means configuration changes are rolled out to existing volumes.
+	ConfigurationRolloutRollingUpdate ReplicatedStorageClassConfigurationRolloutStrategyType = "RollingUpdate"
+	// ConfigurationRolloutNewVolumesOnly means configuration changes only apply to newly created volumes.
+	ConfigurationRolloutNewVolumesOnly ReplicatedStorageClassConfigurationRolloutStrategyType = "NewVolumesOnly"
 )
 
 func (t ReplicatedStorageClassConfigurationRolloutStrategyType) String() string { return string(t) }
@@ -297,10 +297,10 @@ type ReplicatedStorageClassEligibleNodesConflictResolutionStrategy struct {
 type ReplicatedStorageClassEligibleNodesConflictResolutionStrategyType string
 
 const (
-	// ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeManual means conflicts are resolved manually.
-	ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeManual ReplicatedStorageClassEligibleNodesConflictResolutionStrategyType = "Manual"
-	// ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeRollingRepair means replicas are moved automatically when eligible nodes change.
-	ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeRollingRepair ReplicatedStorageClassEligibleNodesConflictResolutionStrategyType = "RollingRepair"
+	// EligibleNodesConflictResolutionManual means conflicts are resolved manually.
+	EligibleNodesConflictResolutionManual ReplicatedStorageClassEligibleNodesConflictResolutionStrategyType = "Manual"
+	// EligibleNodesConflictResolutionRollingRepair means replicas are moved automatically when eligible nodes change.
+	EligibleNodesConflictResolutionRollingRepair ReplicatedStorageClassEligibleNodesConflictResolutionStrategyType = "RollingRepair"
 )
 
 func (t ReplicatedStorageClassEligibleNodesConflictResolutionStrategyType) String() string {

--- a/api/v1alpha1/rsp_types.go
+++ b/api/v1alpha1/rsp_types.go
@@ -187,8 +187,10 @@ type ReplicatedStoragePoolUsedBy struct {
 // Deprecated: Used only by the old controller.
 type ReplicatedStoragePoolPhase string
 
-// ReplicatedStoragePool phase values.
+// TODO: Remove phase constants once the old controller (sds-replicated-volume-controller) is retired.
 // Deprecated: Used only by the old controller.
+//
+// ReplicatedStoragePool phase values.
 const (
 	RSPPhaseCompleted ReplicatedStoragePoolPhase = "Completed"
 	RSPPhaseFailed    ReplicatedStoragePoolPhase = "Failed"

--- a/images/controller/internal/controllers/rsc_controller/reconciler.go
+++ b/images/controller/internal/controllers/rsc_controller/reconciler.go
@@ -489,14 +489,14 @@ func newRVView(unsafeRV *v1alpha1.ReplicatedVolume) rvView {
 // computeRollingStrategiesConfiguration determines max parallel limits for configuration rollouts and conflict resolutions.
 // Returns 0 for a strategy if it's not set to RollingUpdate/RollingRepair type (meaning disabled).
 func computeRollingStrategiesConfiguration(rsc *v1alpha1.ReplicatedStorageClass) (maxParallelConfigurationRollouts, maxParallelConflictResolutions int32) {
-	if rsc.Spec.ConfigurationRolloutStrategy.Type == v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeRollingUpdate {
+	if rsc.Spec.ConfigurationRolloutStrategy.Type == v1alpha1.ConfigurationRolloutRollingUpdate {
 		if rsc.Spec.ConfigurationRolloutStrategy.RollingUpdate == nil {
 			panic("ConfigurationRolloutStrategy.RollingUpdate is nil but Type is RollingUpdate; API validation should prevent this")
 		}
 		maxParallelConfigurationRollouts = rsc.Spec.ConfigurationRolloutStrategy.RollingUpdate.MaxParallel
 	}
 
-	if rsc.Spec.EligibleNodesConflictResolutionStrategy.Type == v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeRollingRepair {
+	if rsc.Spec.EligibleNodesConflictResolutionStrategy.Type == v1alpha1.EligibleNodesConflictResolutionRollingRepair {
 		if rsc.Spec.EligibleNodesConflictResolutionStrategy.RollingRepair == nil {
 			panic("EligibleNodesConflictResolutionStrategy.RollingRepair is nil but Type is RollingRepair; API validation should prevent this")
 		}
@@ -715,7 +715,7 @@ func validateAvailabilityReplication(
 	zonesWithDisks int,
 ) error {
 	switch topology {
-	case v1alpha1.RSCTopologyTransZonal:
+	case v1alpha1.TopologyTransZonal:
 		// 3 different zones, at least 2 with disks.
 		if len(nodesByZone) < 3 {
 			return fmt.Errorf("replication Availability with TransZonal topology requires nodes in at least 3 zones, have %d", len(nodesByZone))
@@ -724,7 +724,7 @@ func validateAvailabilityReplication(
 			return fmt.Errorf("replication Availability with TransZonal topology requires at least 2 zones with disks, have %d", zonesWithDisks)
 		}
 
-	case v1alpha1.RSCTopologyZonal:
+	case v1alpha1.TopologyZonal:
 		// Per zone: at least 3 nodes, at least 2 with disks.
 		for zone, nodes := range nodesByZone {
 			zoneNodesWithDisks := 0
@@ -762,13 +762,13 @@ func validateConsistencyReplication(
 	zonesWithDisks int,
 ) error {
 	switch topology {
-	case v1alpha1.RSCTopologyTransZonal:
+	case v1alpha1.TopologyTransZonal:
 		// 2 different zones with disks.
 		if zonesWithDisks < 2 {
 			return fmt.Errorf("replication Consistency with TransZonal topology requires at least 2 zones with disks, have %d", zonesWithDisks)
 		}
 
-	case v1alpha1.RSCTopologyZonal:
+	case v1alpha1.TopologyZonal:
 		// Per zone: at least 2 nodes with disks.
 		for zone, nodes := range nodesByZone {
 			zoneNodesWithDisks := 0
@@ -803,13 +803,13 @@ func validateConsistencyAndAvailabilityReplication(
 	zonesWithDisks int,
 ) error {
 	switch topology {
-	case v1alpha1.RSCTopologyTransZonal:
+	case v1alpha1.TopologyTransZonal:
 		// 3 zones with disks.
 		if zonesWithDisks < 3 {
 			return fmt.Errorf("replication ConsistencyAndAvailability with TransZonal topology requires at least 3 zones with disks, have %d", zonesWithDisks)
 		}
 
-	case v1alpha1.RSCTopologyZonal:
+	case v1alpha1.TopologyZonal:
 		// Per zone: at least 3 nodes with disks.
 		for zone, nodes := range nodesByZone {
 			zoneNodesWithDisks := 0

--- a/images/controller/internal/controllers/rsc_controller/reconciler_test.go
+++ b/images/controller/internal/controllers/rsc_controller/reconciler_test.go
@@ -268,7 +268,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -286,7 +286,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -304,7 +304,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -325,7 +325,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyTransZonal,
+					Topology:    v1alpha1.TopologyTransZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -343,7 +343,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyTransZonal,
+					Topology:    v1alpha1.TopologyTransZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -361,7 +361,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyTransZonal,
+					Topology:    v1alpha1.TopologyTransZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -382,7 +382,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyZonal,
+					Topology:    v1alpha1.TopologyZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -400,7 +400,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyZonal,
+					Topology:    v1alpha1.TopologyZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -418,7 +418,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationAvailability,
-					Topology:    v1alpha1.RSCTopologyZonal,
+					Topology:    v1alpha1.TopologyZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -439,7 +439,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistency,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -456,7 +456,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistency,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -473,7 +473,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistency,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -493,7 +493,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistency,
-					Topology:    v1alpha1.RSCTopologyTransZonal,
+					Topology:    v1alpha1.TopologyTransZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -510,7 +510,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistency,
-					Topology:    v1alpha1.RSCTopologyTransZonal,
+					Topology:    v1alpha1.TopologyTransZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -530,7 +530,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistency,
-					Topology:    v1alpha1.RSCTopologyZonal,
+					Topology:    v1alpha1.TopologyZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -547,7 +547,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistency,
-					Topology:    v1alpha1.RSCTopologyZonal,
+					Topology:    v1alpha1.TopologyZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -567,7 +567,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistencyAndAvailability,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -585,7 +585,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistencyAndAvailability,
-					Topology:    v1alpha1.RSCTopologyIgnored,
+					Topology:    v1alpha1.TopologyIgnored,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -605,7 +605,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistencyAndAvailability,
-					Topology:    v1alpha1.RSCTopologyTransZonal,
+					Topology:    v1alpha1.TopologyTransZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -623,7 +623,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistencyAndAvailability,
-					Topology:    v1alpha1.RSCTopologyTransZonal,
+					Topology:    v1alpha1.TopologyTransZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -643,7 +643,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistencyAndAvailability,
-					Topology:    v1alpha1.RSCTopologyZonal,
+					Topology:    v1alpha1.TopologyZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -661,7 +661,7 @@ var _ = Describe("validateEligibleNodes", func() {
 			rsc := &v1alpha1.ReplicatedStorageClass{
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication: v1alpha1.ReplicationConsistencyAndAvailability,
-					Topology:    v1alpha1.RSCTopologyZonal,
+					Topology:    v1alpha1.TopologyZonal,
 				},
 			}
 			nodes := []v1alpha1.ReplicatedStoragePoolEligibleNode{
@@ -723,10 +723,10 @@ var _ = Describe("computeRollingStrategiesConfiguration", func() {
 		rsc := &v1alpha1.ReplicatedStorageClass{
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
 				ConfigurationRolloutStrategy: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategy{
-					Type: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeNewVolumesOnly,
+					Type: v1alpha1.ConfigurationRolloutNewVolumesOnly,
 				},
 				EligibleNodesConflictResolutionStrategy: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategy{
-					Type: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeManual,
+					Type: v1alpha1.EligibleNodesConflictResolutionManual,
 				},
 			},
 		}
@@ -741,13 +741,13 @@ var _ = Describe("computeRollingStrategiesConfiguration", func() {
 		rsc := &v1alpha1.ReplicatedStorageClass{
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
 				ConfigurationRolloutStrategy: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategy{
-					Type: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeRollingUpdate,
+					Type: v1alpha1.ConfigurationRolloutRollingUpdate,
 					RollingUpdate: &v1alpha1.ReplicatedStorageClassConfigurationRollingUpdateStrategy{
 						MaxParallel: 5,
 					},
 				},
 				EligibleNodesConflictResolutionStrategy: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategy{
-					Type: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeManual,
+					Type: v1alpha1.EligibleNodesConflictResolutionManual,
 				},
 			},
 		}
@@ -762,10 +762,10 @@ var _ = Describe("computeRollingStrategiesConfiguration", func() {
 		rsc := &v1alpha1.ReplicatedStorageClass{
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
 				ConfigurationRolloutStrategy: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategy{
-					Type: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeNewVolumesOnly,
+					Type: v1alpha1.ConfigurationRolloutNewVolumesOnly,
 				},
 				EligibleNodesConflictResolutionStrategy: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategy{
-					Type: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeRollingRepair,
+					Type: v1alpha1.EligibleNodesConflictResolutionRollingRepair,
 					RollingRepair: &v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionRollingRepair{
 						MaxParallel: 10,
 					},
@@ -783,13 +783,13 @@ var _ = Describe("computeRollingStrategiesConfiguration", func() {
 		rsc := &v1alpha1.ReplicatedStorageClass{
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
 				ConfigurationRolloutStrategy: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategy{
-					Type: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeRollingUpdate,
+					Type: v1alpha1.ConfigurationRolloutRollingUpdate,
 					RollingUpdate: &v1alpha1.ReplicatedStorageClassConfigurationRollingUpdateStrategy{
 						MaxParallel: 3,
 					},
 				},
 				EligibleNodesConflictResolutionStrategy: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategy{
-					Type: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeRollingRepair,
+					Type: v1alpha1.EligibleNodesConflictResolutionRollingRepair,
 					RollingRepair: &v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionRollingRepair{
 						MaxParallel: 7,
 					},
@@ -807,11 +807,11 @@ var _ = Describe("computeRollingStrategiesConfiguration", func() {
 		rsc := &v1alpha1.ReplicatedStorageClass{
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
 				ConfigurationRolloutStrategy: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategy{
-					Type:          v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeRollingUpdate,
+					Type:          v1alpha1.ConfigurationRolloutRollingUpdate,
 					RollingUpdate: nil,
 				},
 				EligibleNodesConflictResolutionStrategy: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategy{
-					Type: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeManual,
+					Type: v1alpha1.EligibleNodesConflictResolutionManual,
 				},
 			},
 		}
@@ -825,10 +825,10 @@ var _ = Describe("computeRollingStrategiesConfiguration", func() {
 		rsc := &v1alpha1.ReplicatedStorageClass{
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
 				ConfigurationRolloutStrategy: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategy{
-					Type: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeNewVolumesOnly,
+					Type: v1alpha1.ConfigurationRolloutNewVolumesOnly,
 				},
 				EligibleNodesConflictResolutionStrategy: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategy{
-					Type:          v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeRollingRepair,
+					Type:          v1alpha1.EligibleNodesConflictResolutionRollingRepair,
 					RollingRepair: nil,
 				},
 			},
@@ -878,10 +878,10 @@ var _ = Describe("ensureVolumeSummaryAndConditions", func() {
 			},
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
 				ConfigurationRolloutStrategy: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategy{
-					Type: v1alpha1.ReplicatedStorageClassConfigurationRolloutStrategyTypeNewVolumesOnly,
+					Type: v1alpha1.ConfigurationRolloutNewVolumesOnly,
 				},
 				EligibleNodesConflictResolutionStrategy: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategy{
-					Type: v1alpha1.ReplicatedStorageClassEligibleNodesConflictResolutionStrategyTypeManual,
+					Type: v1alpha1.EligibleNodesConflictResolutionManual,
 				},
 			},
 			Status: v1alpha1.ReplicatedStorageClassStatus{
@@ -1052,7 +1052,7 @@ var _ = Describe("makeConfiguration", func() {
 	It("copies all fields from spec correctly", func() {
 		rsc := &v1alpha1.ReplicatedStorageClass{
 			Spec: v1alpha1.ReplicatedStorageClassSpec{
-				Topology:     v1alpha1.RSCTopologyTransZonal,
+				Topology:     v1alpha1.TopologyTransZonal,
 				Replication:  v1alpha1.ReplicationAvailability,
 				VolumeAccess: v1alpha1.VolumeAccessLocal,
 			},
@@ -1060,7 +1060,7 @@ var _ = Describe("makeConfiguration", func() {
 
 		config := makeConfiguration(rsc, "my-storage-pool")
 
-		Expect(config.Topology).To(Equal(v1alpha1.RSCTopologyTransZonal))
+		Expect(config.Topology).To(Equal(v1alpha1.TopologyTransZonal))
 		Expect(config.Replication).To(Equal(v1alpha1.ReplicationAvailability))
 		Expect(config.VolumeAccess).To(Equal(v1alpha1.VolumeAccessLocal))
 		Expect(config.StoragePoolName).To(Equal("my-storage-pool"))
@@ -2093,7 +2093,7 @@ var _ = Describe("Reconciler", func() {
 				Spec: v1alpha1.ReplicatedStorageClassSpec{
 					Replication:  v1alpha1.ReplicationNone,
 					VolumeAccess: v1alpha1.VolumeAccessPreferablyLocal,
-					Topology:     v1alpha1.RSCTopologyIgnored,
+					Topology:     v1alpha1.TopologyIgnored,
 				},
 				Status: v1alpha1.ReplicatedStorageClassStatus{
 					StoragePoolBasedOnGeneration:     6,


### PR DESCRIPTION
Renamed enum constants for better readability:
- RSCTopology* → Topology* (TransZonal, Zonal, Ignored)
- ReplicatedStorageClassConfigurationRolloutStrategyType* → ConfigurationRollout* (RollingUpdate, NewVolumesOnly)
- ReplicatedStorageClassEligibleNodesConflictResolutionStrategyType* → EligibleNodesConflictResolution* (Manual, RollingRepair)

Also reorder comments for deprecated RSP phase constants.
