### PR TITLE
[agent] Replace drbdsetup status polling with events2 state store

### DIFF
--- a/images/agent/internal/controllers/drbdr/actual_drbd_state.go
+++ b/images/agent/internal/controllers/drbdr/actual_drbd_state.go
@@ -816,10 +816,36 @@ func (p *actualPath) Established() bool {
 
 var _ ActualPath = &actualPath{}
 
-// observeActualDRBDState retrieves the DRBD resource state by querying
-// drbdsetup status and drbdsetup show. It does NOT probe disk metadata;
-// call observeActualDiskState separately when disk information is needed.
-func observeActualDRBDState(ctx context.Context, drbdResName string) (*actualState, error) {
+// observeActualDRBDState reads the DRBD resource runtime state from the
+// events2-backed state store and configuration from the show cache.
+// It does NOT probe disk metadata; call observeActualDiskState separately.
+func observeActualDRBDState(ctx context.Context, drbdResName string, store *DRBDStateStore, showCache *ShowCache) (*actualState, error) {
+	if !store.WaitReady(ctx) {
+		return nil, ctx.Err()
+	}
+
+	state := &actualState{}
+
+	statusSnapshot := store.Snapshot(drbdResName)
+	if statusSnapshot == nil {
+		return state, nil
+	}
+	state.status = statusSnapshot
+
+	showResult, err := showCache.Get(ctx, drbdResName)
+	if err != nil {
+		return nil, fmt.Errorf("getting show data: %w", err)
+	}
+	state.show = showResult
+
+	return state, nil
+}
+
+// observeActualDRBDStateFresh bypasses the state store and calls drbdsetup
+// status directly, then reads configuration from the show cache.
+// Used for post-convergence refresh where the state store may not yet reflect
+// changes made by DRBD actions.
+func observeActualDRBDStateFresh(ctx context.Context, drbdResName string, showCache *ShowCache) (*actualState, error) {
 	state := &actualState{}
 
 	statusResult, err := drbdutils.ExecuteStatus(ctx, drbdResName)
@@ -830,16 +856,11 @@ func observeActualDRBDState(ctx context.Context, drbdResName string) (*actualSta
 	if len(statusResult) == 1 {
 		state.status = &statusResult[0]
 
-		showResults, err := drbdutils.ExecuteShow(ctx, drbdResName, true)
+		showResult, err := showCache.Get(ctx, drbdResName)
 		if err != nil {
-			return nil, fmt.Errorf("executing drbdsetup show: %w", err)
+			return nil, fmt.Errorf("getting show data: %w", err)
 		}
-		for i := range showResults {
-			if showResults[i].Resource == drbdResName {
-				state.show = &showResults[i]
-				break
-			}
-		}
+		state.show = showResult
 	}
 
 	return state, nil

--- a/images/agent/internal/controllers/drbdr/controller.go
+++ b/images/agent/internal/controllers/drbdr/controller.go
@@ -73,8 +73,11 @@ func BuildController(mgr manager.Manager) error {
 	// Create DRBD port cache (scanner-maintained, will be used by PortRegistry later)
 	drbdPortCache := NewDRBDPortCache()
 
-	// Create scanner with port cache
-	scanner := NewScanner(requestCh, drbdPortCache)
+	// Create DRBD state store (scanner-maintained, read by reconcilers)
+	drbdStateStore := NewDRBDStateStore()
+
+	// Create scanner with port cache and state store
+	scanner := NewScanner(requestCh, drbdPortCache, drbdStateStore)
 	if err := mgr.Add(scanner); err != nil {
 		return fmt.Errorf("adding scanner runnable: %w", err)
 	}
@@ -82,8 +85,11 @@ func BuildController(mgr manager.Manager) error {
 	// Create port registry (reconciler-owned, uses DRBDPortCache for kernel state)
 	portRegistry := NewPortRegistry(cl, nodeName, drbdPortCache, cfg.DRBDMinPort(), cfg.DRBDMaxPort(), 10*time.Minute)
 
+	// Create show cache (caches drbdsetup show results, invalidated after convergence)
+	showCache := NewShowCache()
+
 	// Create reconciler (implements reconcile.TypedReconciler[DRBDReconcileRequest])
-	rec := NewReconciler(cl, nodeName, portRegistry)
+	rec := NewReconciler(cl, nodeName, portRegistry, drbdStateStore, showCache)
 
 	// Build DRBD resource controller with TypedReconciler
 	if err := builder.TypedControllerManagedBy[DRBDReconcileRequest](mgr).

--- a/images/agent/internal/controllers/drbdr/reconciler.go
+++ b/images/agent/internal/controllers/drbdr/reconciler.go
@@ -42,16 +42,20 @@ type Reconciler struct {
 	cl           client.Client
 	nodeName     string
 	portRegistry *PortRegistry
+	stateStore   *DRBDStateStore
+	showCache    *ShowCache
 }
 
 var _ reconcile.TypedReconciler[DRBDReconcileRequest] = (*Reconciler)(nil)
 
 // NewReconciler creates a new Reconciler.
-func NewReconciler(cl client.Client, nodeName string, portRegistry *PortRegistry) *Reconciler {
+func NewReconciler(cl client.Client, nodeName string, portRegistry *PortRegistry, stateStore *DRBDStateStore, showCache *ShowCache) *Reconciler {
 	return &Reconciler{
 		cl:           cl,
 		nodeName:     nodeName,
 		portRegistry: portRegistry,
+		stateStore:   stateStore,
+		showCache:    showCache,
 	}
 }
 
@@ -176,7 +180,7 @@ func (r *Reconciler) reconcileDRBDR(
 	// Observe DRBD state early — the result is used both by Phase 2
 	// (existing port adoption) and Phase 4 (convergence).
 	drbdResName := DRBDResourceNameOnTheNode(drbdr)
-	aState, aErr := observeActualDRBDState(rf.Ctx(), drbdResName)
+	aState, aErr := observeActualDRBDState(rf.Ctx(), drbdResName, r.stateStore, r.showCache)
 	aErr = ConfiguredReasonError(aErr, v1alpha1.DRBDResourceCondConfiguredReasonStateQueryFailed)
 
 	// Phase 2: Ensure addresses are persisted (patch with optimistic lock).
@@ -243,7 +247,8 @@ func (r *Reconciler) reconcileDRBDR(
 
 	var aErr2 error
 	if refreshNeeded {
-		aState, aErr2 = observeActualDRBDState(rf.Ctx(), drbdResName)
+		r.showCache.Invalidate(drbdResName)
+		aState, aErr2 = observeActualDRBDStateFresh(rf.Ctx(), drbdResName, r.showCache)
 		if aErr2 == nil {
 			aErr2 = observeActualDiskState(rf.Ctx(), aState, intendedDisk, drbdr.Status.DeviceUUID)
 		}
@@ -317,11 +322,7 @@ func (r *Reconciler) reconcileOrphanDRBD(
 	rf := flow.BeginReconcile(ctx, "orphan-drbd", "drbdResourceName", drbdName)
 	defer rf.OnEnd(&outcome)
 
-	status, err := drbdutils.ExecuteStatus(rf.Ctx(), drbdName)
-	if err != nil {
-		return rf.Fail(err)
-	}
-	if len(status) == 0 {
+	if !r.stateStore.ResourceExists(drbdName) {
 		return rf.Done()
 	}
 
@@ -361,11 +362,7 @@ func (r *Reconciler) reconcileActualNameOnTheNode(
 
 	case errors.Is(err, drbdutils.ErrRenameUnknownResource):
 		// Old name doesn't exist - check if new name exists (rename might have succeeded before)
-		status, statusErr := drbdutils.ExecuteStatus(rf.Ctx(), newName)
-		if statusErr != nil {
-			return rf.Fail(statusErr)
-		}
-		if len(status) == 0 {
+		if !r.stateStore.ResourceExists(newName) {
 			// Neither old nor new name exists - error
 			return rf.Failf(err, "DRBD resource not found: oldName=%s, newName=%s", oldName, newName)
 		}

--- a/images/agent/internal/controllers/drbdr/reconciler_test.go
+++ b/images/agent/internal/controllers/drbdr/reconciler_test.go
@@ -60,6 +60,10 @@ type reconcileTestCase struct {
 	// Override reconcile request (default: {Name: drbdr.Name or testDRBDRName})
 	request *drbdr.DRBDReconcileRequest
 
+	// State store initial state (events2-backed runtime state).
+	// nil = empty store (no DRBD resources known).
+	storeState drbdutils.StatusResult
+
 	// Expected drbdsetup commands (in order)
 	expectedCommands []*fakedrbdutils.ExpectedCmd
 
@@ -117,19 +121,17 @@ func TestReconciler_Reconcile(t *testing.T) {
 		{
 			name:  "resource not found by name, no DRBD on node - done",
 			drbdr: nil,
-			// K8S object doesn't exist; orphan check queries DRBD status
+			// K8S object doesn't exist; orphan check reads state store
 			// and finds nothing on the node.
-			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{}),
-			},
+			expectedCommands: []*fakedrbdutils.ExpectedCmd{},
 		},
 		{
 			name:  "resource not found by name, DRBD exists on node - orphan cleanup",
 			drbdr: nil,
-			// K8S object doesn't exist but DRBD resource is running on the
-			// node. The reconciler tears it down.
+			// K8S object doesn't exist but state store shows DRBD resource
+			// running. The reconciler tears it down.
+			storeState: configuredStatus(testDRBDResName),
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(configuredStatus(testDRBDResName)),
 				downCmd(testDRBDResName),
 			},
 		},
@@ -152,17 +154,13 @@ func TestReconciler_Reconcile(t *testing.T) {
 		{
 			name:  "state up, drbd not configured - creates resource and minor",
 			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateUp),
+			// State store has no resource → initial observe returns empty
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{}),
-				// After status returns empty, actions are generated:
-				// NewResourceAction calls new-resource
+				// Actions generated from empty actual state:
 				newResourceCmd(testDRBDResName, 0),
-				// ResourceOptionsAction sets resource options
 				resourceOptionsCmd(testDRBDResName),
-				// NewMinorAction calls ExecuteNewAutoMinor which tries nextDeviceMinor=0 first
 				newMinorCmd(testDRBDResName, 0, 0, false),
-				// EnsureDeviceSymlinkAction runs (filesystem, not drbdsetup)
-				// After actions, refresh actual state
+				// Post-convergence refresh (direct status + show cache)
 				statusCmd(configuredStatus(testDRBDResName)),
 				showCmd(configuredShow(testDRBDResName)),
 			},
@@ -195,13 +193,14 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			name:  "state up, drbd configured - queries status and show only",
-			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateUp),
+			name:       "state up, drbd configured - reads from store, show cache miss",
+			drbdr:      drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateUp),
+			storeState: configuredStatus(testDRBDResName),
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(configuredStatus(testDRBDResName)),
+				// Initial observe: store has resource, show cache miss
 				showCmd(configuredShow(testDRBDResName)),
-				// Resource exists and options match - EnsureDeviceSymlinkAction runs (filesystem only)
-				// Refresh after symlink action
+				// EnsureDeviceSymlinkAction runs (filesystem only)
+				// Post-convergence refresh (direct status + show re-fetch)
 				statusCmd(configuredStatus(testDRBDResName)),
 				showCmd(configuredShow(testDRBDResName)),
 			},
@@ -211,17 +210,14 @@ func TestReconciler_Reconcile(t *testing.T) {
 		},
 
 		{
-			name:  "state up, drbd configured as primary - reports device open and io suspended",
-			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateUp),
+			name:       "state up, drbd configured as primary - reports device open and io suspended",
+			drbdr:      drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateUp),
+			storeState: configuredPrimaryStatus(testDRBDResName),
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				{
-					Name:         drbdutils.DRBDSetupCommand,
-					Args:         drbdutils.StatusArgs(testDRBDResName),
-					ResultOutput: mustJSON(configuredPrimaryStatus(testDRBDResName)),
-				},
+				// Initial observe: store has primary resource, show cache miss
 				showCmd(configuredShow(testDRBDResName)),
 				// EnsureDeviceSymlinkAction runs (filesystem only)
-				// Refresh after symlink action
+				// Post-convergence refresh (direct status + show re-fetch)
 				{
 					Name:         drbdutils.DRBDSetupCommand,
 					Args:         drbdutils.StatusArgs(testDRBDResName),
@@ -249,14 +245,14 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 
-		// State=Down cases
+		// State=Down cases — store is empty (DRBD not running)
 		{
-			name:  "state down - queries status",
+			name:  "state down - reads from empty store",
 			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateDown),
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{}),
+				// Initial: store empty → no calls
 				// RemoveDeviceSymlinkAction runs (filesystem only)
-				// Refresh after symlink action
+				// Post-convergence refresh (direct status → empty)
 				statusCmd(drbdutils.StatusResult{}),
 			},
 		},
@@ -265,7 +261,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 			drbdr: drbdrDiskfulDown(testNodeName, testLLVName, testLLVName),
 			objs:  []client.Object{testLLVWithFinalizer(testLLVName)},
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{}),
+				// Initial: store empty → no calls
+				// Post-convergence refresh (direct status → empty)
 				statusCmd(drbdutils.StatusResult{}),
 			},
 			postCheck: func(t *testing.T, cl client.Client) {
@@ -277,7 +274,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 			drbdr: drbdrDiskfulDown(testNodeName, testLLVName, ""),
 			objs:  []client.Object{testLLVWithFinalizer(testLLVName)},
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{}),
+				// Initial: store empty → no calls
+				// Post-convergence refresh (direct status → empty)
 				statusCmd(drbdutils.StatusResult{}),
 			},
 			postCheck: func(t *testing.T, cl client.Client) {
@@ -289,12 +287,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		// Deletion cases
 		{
-			name:  "deleting resource - queries status",
+			name:  "deleting resource - reads from empty store",
 			drbdr: deletingDRBDR(testNodeName, v1alpha1.AgentFinalizer),
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{}),
+				// Initial: store empty → no calls
 				// RemoveDeviceSymlinkAction runs (filesystem only)
-				// Refresh after symlink action
+				// Post-convergence refresh (direct status → empty)
 				statusCmd(drbdutils.StatusResult{}),
 			},
 		},
@@ -313,14 +311,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 		{
 			name:  "custom drbd resource name in maintenance mode - skips rename",
 			drbdr: drbdrWithCustomNameInMaintenance(testNodeName, testCustomDRBDName),
+			// Store has the resource under its custom name
+			storeState: configuredStatus(testCustomDRBDName),
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
 				// Phase 0 rename is skipped due to MM; falls through to Phase 2+4.
-				// Status and show use the custom (old) name via DRBDResourceNameOnTheNode.
-				{
-					Name:         drbdutils.DRBDSetupCommand,
-					Args:         drbdutils.StatusArgs(testCustomDRBDName),
-					ResultOutput: mustJSON(configuredStatus(testCustomDRBDName)),
-				},
+				// Initial observe: store has resource, show cache miss for custom name
 				{
 					Name:         drbdutils.DRBDSetupCommand,
 					Args:         drbdutils.ShowArgs(testCustomDRBDName, true),
@@ -330,27 +325,15 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 
-		// Error cases - use State=Down to avoid action generation
-		{
-			name:  "status command error - returns error",
-			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateDown),
-			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				{
-					Name:         drbdutils.DRBDSetupCommand,
-					Args:         drbdutils.StatusArgs(testDRBDResName),
-					ResultOutput: []byte("error output"),
-					ResultErr:    fakedrbdutils.ExitErr{Code: 1},
-				},
-			},
-			expectedReconcileErr: "executing drbdsetup status",
-		},
+		// Error cases
 		{
 			name:  "show command error - returns error",
 			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateDown),
+			// Store has the resource → show cache is called → error
+			storeState: drbdutils.StatusResult{
+				{Name: testDRBDResName, NodeID: 0, Role: "Secondary"},
+			},
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{
-					{Name: testDRBDResName, NodeID: 0, Role: "Secondary"},
-				}),
 				{
 					Name:         drbdutils.DRBDSetupCommand,
 					Args:         drbdutils.ShowArgs(testDRBDResName, true),
@@ -360,37 +343,16 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			expectedReconcileErr: "executing drbdsetup show",
 		},
-		{
-			name:  "status exit code 10 - resource not found, creates resource",
-			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateUp),
-			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				{
-					Name:         drbdutils.DRBDSetupCommand,
-					Args:         drbdutils.StatusArgs(testDRBDResName),
-					ResultOutput: []byte(testDRBDResName + ": No such resource\n"),
-					ResultErr:    fakedrbdutils.ExitErr{Code: 10},
-				},
-				// Resource not found triggers creation
-				newResourceCmd(testDRBDResName, 0),
-				// ResourceOptionsAction sets resource options
-				resourceOptionsCmd(testDRBDResName),
-				// ExecuteNewAutoMinor tries nextDeviceMinor=0 first
-				newMinorCmd(testDRBDResName, 0, 0, false),
-				// EnsureDeviceSymlinkAction runs (filesystem, not drbdsetup)
-				// Refresh after actions
-				statusCmd(configuredStatus(testDRBDResName)),
-				showCmd(configuredShow(testDRBDResName)),
-			},
-		},
 
-		// Maintenance mode - returns configured resource
+		// Maintenance mode - reads from store, show cache miss
 		{
-			name:  "maintenance mode - queries status and show",
-			drbdr: drbdrInMaintenance(testNodeName, v1alpha1.MaintenanceModeNoResourceReconciliation),
+			name:       "maintenance mode - reads from store and show cache",
+			drbdr:      drbdrInMaintenance(testNodeName, v1alpha1.MaintenanceModeNoResourceReconciliation),
+			storeState: configuredStatus(testDRBDResName),
 			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(configuredStatus(testDRBDResName)),
+				// Initial observe: store has resource, show cache miss
 				showCmd(configuredShow(testDRBDResName)),
-				// Maintenance mode skips all actions (including EnsureDeviceSymlinkAction)
+				// Maintenance mode skips all actions
 			},
 		},
 
@@ -398,27 +360,28 @@ func TestReconciler_Reconcile(t *testing.T) {
 		{
 			name:  "resource with connections - removes stale peer",
 			drbdr: drbdrOnNode(testNodeName, v1alpha1.DRBDResourceStateUp),
-			expectedCommands: []*fakedrbdutils.ExpectedCmd{
-				statusCmd(drbdutils.StatusResult{
-					{
-						Name:   testDRBDResName,
-						NodeID: 0,
-						Role:   "Primary",
-						Devices: []drbdutils.Device{
-							{Volume: 0, Minor: 1000, DiskState: "UpToDate", Quorum: true},
-						},
-						Connections: []drbdutils.Connection{
-							{
-								PeerNodeID:      1,
-								Name:            "peer-1",
-								ConnectionState: "Connected",
-								PeerDevices: []drbdutils.PeerDevice{
-									{Volume: 0, ReplicationState: "Established", PeerDiskState: "UpToDate"},
-								},
+			storeState: drbdutils.StatusResult{
+				{
+					Name:   testDRBDResName,
+					NodeID: 0,
+					Role:   "Primary",
+					Devices: []drbdutils.Device{
+						{Volume: 0, Minor: 1000, DiskState: "UpToDate", Quorum: true},
+					},
+					Connections: []drbdutils.Connection{
+						{
+							PeerNodeID:      1,
+							Name:            "peer-1",
+							ConnectionState: "Connected",
+							PeerDevices: []drbdutils.PeerDevice{
+								{Volume: 0, ReplicationState: "Established", PeerDiskState: "UpToDate"},
 							},
 						},
 					},
-				}),
+				},
+			},
+			expectedCommands: []*fakedrbdutils.ExpectedCmd{
+				// Initial observe: store has resource with connection, show cache miss
 				showCmd(&drbdutils.ShowResource{
 					Resource: testDRBDResName,
 					Options: drbdutils.ShowOptions{
@@ -434,11 +397,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 					},
 				}),
 				// EnsureDeviceSymlinkAction runs (filesystem, not drbdsetup)
-				// Stale peer (in actual but not in intended spec): disconnect + del-peer + forget-peer
+				// Stale peer: disconnect + del-peer + forget-peer
 				disconnectCmd(testDRBDResName, 1),
 				delPeerCmd(testDRBDResName, 1),
 				forgetPeerCmd(testDRBDResName, 1),
-				// Refresh after actions
+				// Post-convergence refresh (direct status + show re-fetch)
 				statusCmd(configuredStatus(testDRBDResName)),
 				showCmd(configuredShow(testDRBDResName)),
 			},
@@ -500,12 +463,20 @@ func TestReconciler_Reconcile(t *testing.T) {
 			fakeExec.ExpectCommands(tc.expectedCommands...)
 			fakeExec.Setup(t)
 
-			// Create reconciler with port registry
+			// Create reconciler with port registry, state store and show cache
 			drbdPortCache := drbdr.NewDRBDPortCache()
 			drbdPortCache.BeginDump()
 			drbdPortCache.EndDump()
 			portRegistry := drbdr.NewPortRegistry(cl, testNodeName, drbdPortCache, 7000, 7999, 10*time.Minute)
-			rec := drbdr.NewReconciler(cl, testNodeName, portRegistry)
+
+			stateStore := drbdr.NewDRBDStateStore()
+			stateStore.MarkReadyForTest()
+			if tc.storeState != nil {
+				stateStore.PopulateForTest(tc.storeState)
+			}
+			showCache := drbdr.NewShowCache()
+
+			rec := drbdr.NewReconciler(cl, testNodeName, portRegistry, stateStore, showCache)
 
 			// Build reconcile request
 			var req drbdr.DRBDReconcileRequest

--- a/images/agent/internal/controllers/drbdr/scanner.go
+++ b/images/agent/internal/controllers/drbdr/scanner.go
@@ -34,20 +34,24 @@ const (
 
 // Scanner listens for DRBD events via drbdutils events2 and triggers
 // reconciliation of DRBDResource objects by sending events to the controller.
-// It also maintains a DRBDPortCache with port information from path events.
+// It maintains a DRBDPortCache with port information from path events and
+// a DRBDStateStore with full runtime state for reconciler reads.
 type Scanner struct {
-	requestCh chan<- event.TypedGenericEvent[DRBDReconcileRequest]
-	portCache *DRBDPortCache
+	requestCh  chan<- event.TypedGenericEvent[DRBDReconcileRequest]
+	portCache  *DRBDPortCache
+	stateStore *DRBDStateStore
 }
 
 // NewScanner creates a new Scanner.
 func NewScanner(
 	requestCh chan<- event.TypedGenericEvent[DRBDReconcileRequest],
 	portCache *DRBDPortCache,
+	stateStore *DRBDStateStore,
 ) *Scanner {
 	return &Scanner{
-		requestCh: requestCh,
-		portCache: portCache,
+		requestCh:  requestCh,
+		portCache:  portCache,
+		stateStore: stateStore,
 	}
 }
 
@@ -92,10 +96,12 @@ func (s *Scanner) Start(ctx context.Context) error {
 // Returns error if the loop terminates unexpectedly.
 func (s *Scanner) runEventsLoop(ctx context.Context) error {
 	s.portCache.BeginDump()
+	s.stateStore.BeginDump()
 	dumpCompleted := false
 	defer func() {
 		if !dumpCompleted {
 			s.portCache.AbortDump()
+			s.stateStore.AbortDump()
 		}
 	}()
 
@@ -122,8 +128,9 @@ func (s *Scanner) runEventsLoop(ctx context.Context) error {
 			logger.V(1).Info("DRBD event received", "kind", tev.Kind, "object", tev.Object, "state", tev.State)
 
 			// Check for "exists -" which indicates initial state dump is complete
-			if !online && tev.Kind == "exists" && tev.Object == "-" {
+			if !online && tev.Kind == drbdutils.EventKindExists && tev.Object == drbdutils.EventObjectDumpDone {
 				s.portCache.EndDump()
+				s.stateStore.EndDump()
 				dumpCompleted = true
 				online = true
 				logger.Info("DRBD events online", "pendingResources", len(pending))
@@ -133,6 +140,10 @@ func (s *Scanner) runEventsLoop(ctx context.Context) error {
 				}
 				pending = nil // Free memory
 				continue
+			}
+
+			if err := s.stateStore.ApplyEvent(tev); err != nil {
+				logger.Error(err, "Failed to apply event to state store", "kind", tev.Kind, "object", tev.Object)
 			}
 
 			// Process "name" field (present in most events)
@@ -145,14 +156,14 @@ func (s *Scanner) runEventsLoop(ctx context.Context) error {
 			s.updatePortCache(tev, drbdName)
 
 			// For rename events, also process "new_name"
-			if tev.Kind == "rename" {
+			if tev.Kind == drbdutils.EventKindRename {
 				if newName, ok := tev.State["new_name"]; ok {
 					processName(newName)
 				}
 			}
 
 		case *drbdutils.UnparsedEvent:
-			logger.Info("Unparsed event", "error", tev.Err, "line", tev.RawEventLine)
+			logger.Error(tev.Err, "Unparsed DRBD event", "line", tev.RawEventLine)
 		}
 	}
 
@@ -166,7 +177,7 @@ func (s *Scanner) runEventsLoop(ctx context.Context) error {
 // updatePortCache updates the DRBDPortCache based on path and resource events.
 func (s *Scanner) updatePortCache(ev *drbdutils.Event, drbdName string) {
 	switch ev.Object {
-	case "path":
+	case drbdutils.EventObjectPath:
 		local, ok := ev.State["local"]
 		if !ok {
 			return
@@ -176,13 +187,13 @@ func (s *Scanner) updatePortCache(ev *drbdutils.Event, drbdName string) {
 			return
 		}
 		switch ev.Kind {
-		case "exists", "create":
+		case drbdutils.EventKindExists, drbdutils.EventKindCreate:
 			s.portCache.Add(drbdName, ip, port)
-		case "destroy":
+		case drbdutils.EventKindDestroy:
 			s.portCache.Remove(drbdName, ip, port)
 		}
-	case "resource":
-		if ev.Kind == "destroy" {
+	case drbdutils.EventObjectResource:
+		if ev.Kind == drbdutils.EventKindDestroy {
 			s.portCache.RemoveResource(drbdName)
 		}
 	}

--- a/images/agent/internal/controllers/drbdr/show_cache.go
+++ b/images/agent/internal/controllers/drbdr/show_cache.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbdr
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/deckhouse/sds-replicated-volume/images/agent/pkg/drbdutils"
+)
+
+// ShowCache caches per-resource results of drbdsetup show --json --show-defaults.
+// Entries are fetched lazily on first access and invalidated after DRBD convergence
+// actions that may change configuration.
+//
+// Concurrency model:
+//   - Multiple reconciler goroutines may call Get concurrently (read lock).
+//   - Reconciler goroutines may call Invalidate (write lock).
+//   - RWMutex allows concurrent cache hits without blocking.
+type ShowCache struct {
+	mu      sync.RWMutex
+	entries map[string]*showCacheEntry
+}
+
+type showCacheEntry struct {
+	result *drbdutils.ShowResource
+}
+
+func NewShowCache() *ShowCache {
+	return &ShowCache{
+		entries: make(map[string]*showCacheEntry),
+	}
+}
+
+// Get returns the cached show result for a resource, fetching it from drbdsetup
+// if not cached. Returns nil (not error) if the resource is not found in show output.
+func (c *ShowCache) Get(ctx context.Context, resourceName string) (*drbdutils.ShowResource, error) {
+	c.mu.RLock()
+	entry, ok := c.entries[resourceName]
+	c.mu.RUnlock()
+
+	if ok {
+		return entry.result, nil
+	}
+
+	result, err := c.fetchAndStore(ctx, resourceName)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Invalidate marks a resource's cached show result as stale. The next Get call
+// will re-fetch from drbdsetup.
+func (c *ShowCache) Invalidate(resourceName string) {
+	c.mu.Lock()
+	delete(c.entries, resourceName)
+	c.mu.Unlock()
+}
+
+func (c *ShowCache) fetchAndStore(ctx context.Context, resourceName string) (*drbdutils.ShowResource, error) {
+	results, err := drbdutils.ExecuteShow(ctx, resourceName, true)
+	if err != nil {
+		return nil, fmt.Errorf("executing drbdsetup show: %w", err)
+	}
+
+	var match *drbdutils.ShowResource
+	for i := range results {
+		if results[i].Resource == resourceName {
+			match = &results[i]
+			break
+		}
+	}
+
+	c.mu.Lock()
+	c.entries[resourceName] = &showCacheEntry{result: match}
+	c.mu.Unlock()
+
+	return match, nil
+}

--- a/images/agent/internal/controllers/drbdr/state_store.go
+++ b/images/agent/internal/controllers/drbdr/state_store.go
@@ -1,0 +1,542 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbdr
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/deckhouse/sds-replicated-volume/images/agent/pkg/drbdutils"
+)
+
+// DRBDStateStore maintains an in-memory representation of DRBD runtime state,
+// built from events2 stream by the Scanner and read by reconcilers.
+//
+// Concurrency model:
+//   - Scanner goroutine is the sole writer (BeginDump/EndDump/ApplyEvent).
+//   - Reconciler goroutines are readers (Snapshot/ResourceExists).
+//   - Two independent blocking gates protect readers:
+//     1. readyCh — blocks until the first initial dump completes (one-time).
+//     2. dumpMu  — blocks during any dump (initial or reconnect).
+type DRBDStateStore struct {
+	readyCh   chan struct{}
+	readyOnce sync.Once
+
+	dumpMu sync.RWMutex
+	dataMu sync.RWMutex
+
+	resources map[string]*resourceState
+}
+
+func NewDRBDStateStore() *DRBDStateStore {
+	return &DRBDStateStore{
+		readyCh:   make(chan struct{}),
+		resources: make(map[string]*resourceState),
+	}
+}
+
+// BeginDump prepares for a new events2 initial dump. It blocks all readers
+// (via dumpMu) and clears existing data.
+func (s *DRBDStateStore) BeginDump() {
+	s.dumpMu.Lock()
+	s.dataMu.Lock()
+	s.resources = make(map[string]*resourceState)
+	s.dataMu.Unlock()
+}
+
+// EndDump signals that the events2 dump is complete. It unblocks readers and,
+// on the first call, marks the store as ready.
+func (s *DRBDStateStore) EndDump() {
+	s.readyOnce.Do(func() { close(s.readyCh) })
+	s.dumpMu.Unlock()
+}
+
+// AbortDump releases the dump lock without marking the store as ready.
+func (s *DRBDStateStore) AbortDump() {
+	s.dumpMu.Unlock()
+}
+
+// WaitReady blocks until the store has completed its first dump, or ctx is cancelled.
+func (s *DRBDStateStore) WaitReady(ctx context.Context) bool {
+	select {
+	case <-s.readyCh:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// Snapshot returns a drbdutils.Resource compatible with the drbdsetup status
+// JSON output for the given DRBD resource. Returns nil if the resource is not
+// known to the store.
+func (s *DRBDStateStore) Snapshot(resourceName string) *drbdutils.Resource {
+	s.dumpMu.RLock()
+	defer s.dumpMu.RUnlock()
+	s.dataMu.RLock()
+	defer s.dataMu.RUnlock()
+
+	rs, ok := s.resources[resourceName]
+	if !ok {
+		return nil
+	}
+	return rs.toStatusResource(resourceName)
+}
+
+// ResourceExists returns true if the resource is known to the store.
+func (s *DRBDStateStore) ResourceExists(resourceName string) bool {
+	s.dumpMu.RLock()
+	defer s.dumpMu.RUnlock()
+	s.dataMu.RLock()
+	defer s.dataMu.RUnlock()
+	_, ok := s.resources[resourceName]
+	return ok
+}
+
+// ApplyEvent updates the store with an events2 event. Called by the Scanner.
+// Returns an error when the event cannot be applied (missing fields, unknown kind).
+// The caller is expected to log the error.
+func (s *DRBDStateStore) ApplyEvent(ev *drbdutils.Event) error {
+	if ev.Object == drbdutils.EventObjectDumpDone {
+		return nil
+	}
+	name, ok := ev.State["name"]
+	if !ok {
+		return fmt.Errorf("event %s %s has no 'name' field", ev.Kind, ev.Object)
+	}
+
+	s.dataMu.Lock()
+	defer s.dataMu.Unlock()
+
+	switch ev.Kind {
+	case drbdutils.EventKindExists, drbdutils.EventKindCreate, drbdutils.EventKindChange:
+		s.upsertObject(name, ev)
+	case drbdutils.EventKindDestroy:
+		s.destroyObject(name, ev)
+	case drbdutils.EventKindRename:
+		newName, ok := ev.State["new_name"]
+		if !ok {
+			return fmt.Errorf("rename event for %q has no 'new_name' field", name)
+		}
+		rs, exists := s.resources[name]
+		if !exists {
+			return fmt.Errorf("rename event for %q: resource not found in store", name)
+		}
+		delete(s.resources, name)
+		s.resources[newName] = rs
+	default:
+		return fmt.Errorf("unhandled event kind %q for object %s %q", ev.Kind, ev.Object, name)
+	}
+	return nil
+}
+
+func (s *DRBDStateStore) upsertObject(name string, ev *drbdutils.Event) {
+	switch ev.Object {
+	case drbdutils.EventObjectResource:
+		rs := s.getOrCreateResource(name)
+		applyResourceFields(rs, ev.State)
+	case drbdutils.EventObjectDevice:
+		rs := s.getOrCreateResource(name)
+		vol := parseIntField(ev.State, "volume")
+		ds := rs.getOrCreateDevice(vol)
+		applyDeviceFields(ds, ev.State)
+	case drbdutils.EventObjectConnection:
+		rs := s.getOrCreateResource(name)
+		peerNodeID := parseIntField(ev.State, "peer-node-id")
+		cs := rs.getOrCreateConnection(peerNodeID)
+		applyConnectionFields(cs, ev.State)
+	case drbdutils.EventObjectPeerDevice:
+		rs := s.getOrCreateResource(name)
+		peerNodeID := parseIntField(ev.State, "peer-node-id")
+		vol := parseIntField(ev.State, "volume")
+		cs := rs.getOrCreateConnection(peerNodeID)
+		pds := cs.getOrCreatePeerDevice(vol)
+		applyPeerDeviceFields(pds, ev.State)
+	case drbdutils.EventObjectPath:
+		rs := s.getOrCreateResource(name)
+		peerNodeID := parseIntField(ev.State, "peer-node-id")
+		cs := rs.getOrCreateConnection(peerNodeID)
+		localKey := ev.State["local"]
+		if localKey == "" {
+			return
+		}
+		ps := cs.getOrCreatePath(localKey)
+		applyPathFields(ps, ev.State)
+	}
+}
+
+func (s *DRBDStateStore) destroyObject(name string, ev *drbdutils.Event) {
+	rs, ok := s.resources[name]
+	if !ok {
+		return
+	}
+
+	switch ev.Object {
+	case drbdutils.EventObjectResource:
+		delete(s.resources, name)
+	case drbdutils.EventObjectDevice:
+		vol := parseIntField(ev.State, "volume")
+		delete(rs.devices, vol)
+	case drbdutils.EventObjectConnection:
+		peerNodeID := parseIntField(ev.State, "peer-node-id")
+		delete(rs.connections, peerNodeID)
+	case drbdutils.EventObjectPeerDevice:
+		peerNodeID := parseIntField(ev.State, "peer-node-id")
+		vol := parseIntField(ev.State, "volume")
+		if cs, ok := rs.connections[peerNodeID]; ok {
+			delete(cs.peerDevices, vol)
+		}
+	case drbdutils.EventObjectPath:
+		peerNodeID := parseIntField(ev.State, "peer-node-id")
+		localKey := ev.State["local"]
+		if cs, ok := rs.connections[peerNodeID]; ok {
+			delete(cs.paths, localKey)
+		}
+	}
+}
+
+func (s *DRBDStateStore) getOrCreateResource(name string) *resourceState {
+	rs, ok := s.resources[name]
+	if !ok {
+		rs = &resourceState{
+			devices:     make(map[int]*deviceState),
+			connections: make(map[int]*connectionState),
+		}
+		s.resources[name] = rs
+	}
+	return rs
+}
+
+// Internal state types
+
+type resourceState struct {
+	role            string
+	suspended       bool
+	forceIOFailures bool
+
+	devices     map[int]*deviceState
+	connections map[int]*connectionState
+}
+
+func (rs *resourceState) getOrCreateDevice(vol int) *deviceState {
+	ds, ok := rs.devices[vol]
+	if !ok {
+		ds = &deviceState{}
+		rs.devices[vol] = ds
+	}
+	return ds
+}
+
+func (rs *resourceState) getOrCreateConnection(peerNodeID int) *connectionState {
+	cs, ok := rs.connections[peerNodeID]
+	if !ok {
+		cs = &connectionState{
+			paths:       make(map[string]*pathState),
+			peerDevices: make(map[int]*peerDeviceState),
+		}
+		rs.connections[peerNodeID] = cs
+	}
+	return cs
+}
+
+type deviceState struct {
+	minor     int
+	diskState string
+	client    bool
+	open      bool
+	quorum    bool
+	sizeKiB   int
+}
+
+type connectionState struct {
+	name            string
+	connectionState string
+	peerRole        string
+
+	paths       map[string]*pathState
+	peerDevices map[int]*peerDeviceState
+}
+
+func (cs *connectionState) getOrCreatePeerDevice(vol int) *peerDeviceState {
+	pds, ok := cs.peerDevices[vol]
+	if !ok {
+		pds = &peerDeviceState{}
+		cs.peerDevices[vol] = pds
+	}
+	return pds
+}
+
+func (cs *connectionState) getOrCreatePath(localKey string) *pathState {
+	ps, ok := cs.paths[localKey]
+	if !ok {
+		ps = &pathState{}
+		cs.paths[localKey] = ps
+	}
+	return ps
+}
+
+type pathState struct {
+	localIP     string
+	localPort   int
+	remoteIP    string
+	remotePort  int
+	established bool
+}
+
+type peerDeviceState struct {
+	replicationState string
+	peerDiskState    string
+	peerClient       bool
+	resyncSuspended  string
+}
+
+// Field application from events2 key-value pairs
+
+func applyResourceFields(rs *resourceState, state map[string]string) {
+	if v, ok := state["role"]; ok {
+		rs.role = v
+	}
+	if v, ok := state["suspended"]; ok {
+		rs.suspended = parseBoolField(v)
+	}
+	if v, ok := state["force-io-failures"]; ok {
+		rs.forceIOFailures = parseBoolField(v)
+	}
+}
+
+func applyDeviceFields(ds *deviceState, state map[string]string) {
+	if v, ok := state["minor"]; ok {
+		ds.minor = parseIntStr(v)
+	}
+	if v, ok := state["disk"]; ok {
+		ds.diskState = v
+	}
+	if v, ok := state["client"]; ok {
+		ds.client = parseBoolField(v)
+	}
+	if v, ok := state["open"]; ok {
+		ds.open = parseBoolField(v)
+	}
+	if v, ok := state["quorum"]; ok {
+		ds.quorum = parseBoolField(v)
+	}
+	if v, ok := state["size"]; ok {
+		ds.sizeKiB = parseIntStr(v)
+	}
+}
+
+func applyConnectionFields(cs *connectionState, state map[string]string) {
+	if v, ok := state["conn-name"]; ok {
+		cs.name = v
+	}
+	if v, ok := state["connection"]; ok {
+		cs.connectionState = v
+	}
+	if v, ok := state["peer-role"]; ok {
+		cs.peerRole = v
+	}
+}
+
+func applyPeerDeviceFields(pds *peerDeviceState, state map[string]string) {
+	if v, ok := state["replication"]; ok {
+		pds.replicationState = v
+	}
+	if v, ok := state["peer-disk"]; ok {
+		pds.peerDiskState = v
+	}
+	if v, ok := state["peer-client"]; ok {
+		pds.peerClient = parseBoolField(v)
+	}
+	if v, ok := state["resync-suspended"]; ok {
+		pds.resyncSuspended = v
+	}
+}
+
+func applyPathFields(ps *pathState, state map[string]string) {
+	if v, ok := state["local"]; ok {
+		ip, port, ok := parseLocalAddr(v)
+		if ok {
+			ps.localIP = ip
+			ps.localPort = int(port)
+		}
+	}
+	if v, ok := state["peer"]; ok {
+		ip, port, ok := parseLocalAddr(v)
+		if ok {
+			ps.remoteIP = ip
+			ps.remotePort = int(port)
+		}
+	}
+	if v, ok := state["established"]; ok {
+		ps.established = parseBoolField(v)
+	}
+}
+
+// Conversion to drbdutils status types
+
+func (rs *resourceState) toStatusResource(name string) *drbdutils.Resource {
+	res := &drbdutils.Resource{
+		Name:            name,
+		Role:            rs.role,
+		Suspended:       rs.suspended,
+		ForceIOFailures: rs.forceIOFailures,
+	}
+
+	volNums := sortedKeys(rs.devices)
+	for _, vol := range volNums {
+		ds := rs.devices[vol]
+		res.Devices = append(res.Devices, drbdutils.Device{
+			Volume:    vol,
+			Minor:     ds.minor,
+			DiskState: ds.diskState,
+			Client:    ds.client,
+			Open:      ds.open,
+			Quorum:    ds.quorum,
+			Size:      ds.sizeKiB,
+		})
+	}
+
+	peerNodeIDs := sortedKeys(rs.connections)
+	for _, peerNodeID := range peerNodeIDs {
+		cs := rs.connections[peerNodeID]
+		conn := drbdutils.Connection{
+			PeerNodeID:      peerNodeID,
+			Name:            cs.name,
+			ConnectionState: cs.connectionState,
+			Peerrole:        cs.peerRole,
+		}
+
+		for _, ps := range cs.paths {
+			conn.Paths = append(conn.Paths, drbdutils.Path{
+				ThisHost: drbdutils.Host{
+					Address: ps.localIP,
+					Port:    ps.localPort,
+					Family:  "ipv4",
+				},
+				RemoteHost: drbdutils.Host{
+					Address: ps.remoteIP,
+					Port:    ps.remotePort,
+					Family:  "ipv4",
+				},
+				Established: ps.established,
+			})
+		}
+
+		peerVolNums := sortedKeys(cs.peerDevices)
+		for _, vol := range peerVolNums {
+			pds := cs.peerDevices[vol]
+			conn.PeerDevices = append(conn.PeerDevices, drbdutils.PeerDevice{
+				Volume:           vol,
+				ReplicationState: pds.replicationState,
+				PeerDiskState:    pds.peerDiskState,
+				PeerClient:       pds.peerClient,
+				ResyncSuspended:  pds.resyncSuspended,
+			})
+		}
+
+		res.Connections = append(res.Connections, conn)
+	}
+
+	return res
+}
+
+// Test helpers
+
+// PopulateForTest fills the store from a StatusResult. For testing only.
+func (s *DRBDStateStore) PopulateForTest(result drbdutils.StatusResult) {
+	s.dataMu.Lock()
+	defer s.dataMu.Unlock()
+
+	for i := range result {
+		res := &result[i]
+		rs := s.getOrCreateResource(res.Name)
+		rs.role = res.Role
+		rs.suspended = res.Suspended
+		rs.forceIOFailures = res.ForceIOFailures
+
+		for j := range res.Devices {
+			dev := &res.Devices[j]
+			ds := rs.getOrCreateDevice(dev.Volume)
+			ds.minor = dev.Minor
+			ds.diskState = dev.DiskState
+			ds.client = dev.Client
+			ds.open = dev.Open
+			ds.quorum = dev.Quorum
+			ds.sizeKiB = dev.Size
+		}
+
+		for j := range res.Connections {
+			conn := &res.Connections[j]
+			cs := rs.getOrCreateConnection(conn.PeerNodeID)
+			cs.name = conn.Name
+			cs.connectionState = conn.ConnectionState
+			cs.peerRole = conn.Peerrole
+
+			for k := range conn.Paths {
+				path := &conn.Paths[k]
+				localKey := fmt.Sprintf("ipv4:%s:%d", path.ThisHost.Address, path.ThisHost.Port)
+				ps := cs.getOrCreatePath(localKey)
+				ps.localIP = path.ThisHost.Address
+				ps.localPort = path.ThisHost.Port
+				ps.remoteIP = path.RemoteHost.Address
+				ps.remotePort = path.RemoteHost.Port
+				ps.established = path.Established
+			}
+
+			for k := range conn.PeerDevices {
+				pd := &conn.PeerDevices[k]
+				pds := cs.getOrCreatePeerDevice(pd.Volume)
+				pds.replicationState = pd.ReplicationState
+				pds.peerDiskState = pd.PeerDiskState
+				pds.peerClient = pd.PeerClient
+				pds.resyncSuspended = pd.ResyncSuspended
+			}
+		}
+	}
+}
+
+// MarkReadyForTest marks the store as ready without going through the dump
+// lifecycle. For testing only.
+func (s *DRBDStateStore) MarkReadyForTest() {
+	s.readyOnce.Do(func() { close(s.readyCh) })
+}
+
+// Parsing helpers
+
+func parseBoolField(s string) bool {
+	return s == "yes"
+}
+
+func parseIntStr(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+func parseIntField(state map[string]string, key string) int {
+	return parseIntStr(state[key])
+}
+
+func sortedKeys[V any](m map[int]V) []int {
+	keys := make([]int, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
+}

--- a/images/agent/pkg/drbdutils/events2.go
+++ b/images/agent/pkg/drbdutils/events2.go
@@ -25,7 +25,7 @@ import (
 	"time"
 )
 
-var Events2Args = []string{"events2", "--timestamps"}
+var Events2Args = []string{"events2", "--timestamps", "--statistics"}
 
 type Events2Result interface {
 	_isEvents2Result()
@@ -33,27 +33,63 @@ type Events2Result interface {
 
 type Event struct {
 	Timestamp time.Time
-	// "exists" for an existing object;
-	//
-	// "create", "destroy", and "change" if an object
-	// is created, destroyed, or changed;
-	//
-	// "call" or "response" if an event handler
-	// is called or it returns;
-	//
-	// or "rename" when the name of an object is changed
-	Kind string
-	// "resource", "device", "connection", "peer-device", "path", "helper", or
-	// a dash ("-") to indicate that the current state has been dumped
-	// completely
-	Object string
-	// Identify the object and describe the state that the object is in
-	State map[string]string
+	Kind      EventKind
+	Object    EventObject
+	State     map[string]string
 }
 
 var _ Events2Result = &Event{}
 
 func (*Event) _isEvents2Result() {}
+
+// EventKind represents the verb in an events2 line.
+type EventKind string
+
+const (
+	EventKindExists   EventKind = "exists"
+	EventKindCreate   EventKind = "create"
+	EventKindDestroy  EventKind = "destroy"
+	EventKindChange   EventKind = "change"
+	EventKindCall     EventKind = "call"
+	EventKindResponse EventKind = "response"
+	EventKindRename   EventKind = "rename"
+)
+
+// parseEventKind returns the typed kind or empty string for unrecognized values.
+func parseEventKind(s string) (EventKind, bool) {
+	switch EventKind(s) {
+	case EventKindExists, EventKindCreate, EventKindDestroy, EventKindChange,
+		EventKindCall, EventKindResponse, EventKindRename:
+		return EventKind(s), true
+	default:
+		return "", false
+	}
+}
+
+// EventObject represents the object type in an events2 line.
+type EventObject string
+
+const (
+	EventObjectResource   EventObject = "resource"
+	EventObjectDevice     EventObject = "device"
+	EventObjectConnection EventObject = "connection"
+	EventObjectPeerDevice EventObject = "peer-device"
+	EventObjectPath       EventObject = "path"
+	EventObjectHelper     EventObject = "helper"
+	EventObjectDumpDone   EventObject = "-"
+)
+
+// parseEventObject returns the typed object or empty string for unrecognized values.
+func parseEventObject(s string) (EventObject, bool) {
+	switch EventObject(s) {
+	case EventObjectResource, EventObjectDevice, EventObjectConnection,
+		EventObjectPeerDevice, EventObjectPath, EventObjectHelper,
+		EventObjectDumpDone:
+		return EventObject(s), true
+	default:
+		return "", false
+	}
+}
 
 type UnparsedEvent struct {
 	RawEventLine string
@@ -130,8 +166,21 @@ func parseLine(line string) Events2Result {
 		}
 	}
 
-	kind := fields[1]
-	object := fields[2]
+	kind, kindOk := parseEventKind(fields[1])
+	if !kindOk {
+		return &UnparsedEvent{
+			RawEventLine: line,
+			Err:          fmt.Errorf("unrecognized event kind %q", fields[1]),
+		}
+	}
+
+	object, objectOk := parseEventObject(fields[2])
+	if !objectOk {
+		return &UnparsedEvent{
+			RawEventLine: line,
+			Err:          fmt.Errorf("unrecognized event object %q", fields[2]),
+		}
+	}
 
 	state := make(map[string]string)
 	for _, kv := range fields[3:] {


### PR DESCRIPTION
## Description

Replace per-reconcile `drbdsetup status` + `drbdsetup show` subprocess calls with an in-memory state store backed by the `events2` stream, plus a lazy show cache for configuration data.

Two new components are introduced in the `drbdr` package:

- **`DRBDStateStore`** — thread-safe store of DRBD runtime state (role, disk-state, connections, paths, etc.), built incrementally from events2 by the Scanner. Provides `Snapshot(resourceName)` that returns a `*drbdutils.Resource` compatible with the existing `actualState` consumption.
- **`ShowCache`** — per-resource cache of `drbdsetup show` results (configuration options, backing disk, net options). Fetched lazily on first access, invalidated after convergence actions.

The reconciler's initial observe phase reads from the store + show cache (zero subprocess calls in steady state). The post-convergence refresh still calls `drbdsetup status` directly for immediate accuracy, then re-fetches show from the invalidated cache.

`--statistics` flag added to events2 args so `size` is available in device events.

## Why do we need it, and what problem does it solve?

Every reconcile of a `DRBDResource` spawned 2 subprocesses (`drbdsetup status` + `drbdsetup show`), and up to 2 more after convergence. With 20 concurrent reconcilers and frequent events, this created excessive process overhead.

The events2 stream already carries all runtime state data — the same data that `drbdsetup status` returns. By maintaining this state in memory and reading from it during reconciliation, we eliminate redundant subprocess calls.

## What is the expected result?

Subprocess calls per reconcile cycle:

| Scenario | Before | After |
|---|---|---|
| Non-converging (steady state) | 2 (status + show) | 0 (first time: 1 show) |
| Converging | 4 (status + show + refresh status + refresh show) | 2 (refresh status + refresh show) |
| Orphan check | 1 (status) | 0 |
| Rename recovery | 1 (status) | 0 |

Functional behavior is preserved — the same `ActualDRBDState` interface is used by downstream code (`Report`, `computeTargetDRBDActions`, etc.) with no changes.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.