### PR TITLE
[agent] Use sysfs instead of drbdsetup show to detect used minors

### DIFF
--- a/images/agent/pkg/drbdutils/commands_test.go
+++ b/images/agent/pkg/drbdutils/commands_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package drbdutils_test
 
 import (
-	"encoding/json"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/deckhouse/sds-replicated-volume/images/agent/pkg/drbdutils"
@@ -96,18 +96,11 @@ func TestExecuteNewMinorKnownErrors(t *testing.T) {
 	})
 
 	t.Run("auto minor retries", func(t *testing.T) {
-		showOutput, err := json.Marshal([]drbdutils.ShowResource{
-			{
-				ThisHost: drbdutils.ShowThisHost{
-					Volumes: []drbdutils.ShowVolume{
-						{DeviceMinor: 0},
-					},
-				},
-			},
-		})
-		if err != nil {
-			t.Fatalf("marshal show output: %v", err)
+		sysBlock := t.TempDir()
+		if err := os.Mkdir(sysBlock+"/drbd0", 0o755); err != nil {
+			t.Fatal(err)
 		}
+		drbdutils.SysBlockPath = sysBlock
 
 		drbdutils.ResetNextDeviceMinor()
 
@@ -118,11 +111,6 @@ func TestExecuteNewMinorKnownErrors(t *testing.T) {
 				Args:         drbdutils.NewMinorArgs("res", 0, 0, false),
 				ResultOutput: []byte("Failure: (161) Minor or volume exists already (delete it first)\n"),
 				ResultErr:    fakedrbdutils.ExitErr{Code: 10},
-			},
-			&fakedrbdutils.ExpectedCmd{
-				Name:         drbdutils.DRBDSetupCommand,
-				Args:         drbdutils.ShowArgs("", false),
-				ResultOutput: showOutput,
 			},
 			&fakedrbdutils.ExpectedCmd{
 				Name: drbdutils.DRBDSetupCommand,

--- a/images/agent/pkg/drbdutils/minor.go
+++ b/images/agent/pkg/drbdutils/minor.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -32,6 +34,9 @@ var (
 	ErrNewMinorResourceNotFound = errors.New("resource not found")
 	ErrNewMinorNoFreeMinor      = errors.New("no free device minor available")
 )
+
+// SysBlockPath is the path to /sys/block. Overridable in tests.
+var SysBlockPath = "/sys/block"
 
 var (
 	nextDeviceMinor   uint
@@ -88,12 +93,12 @@ func ExecuteNewAutoMinor(ctx context.Context, resource string, volume uint, disk
 			return 0, err
 		}
 
-		resources, err := ExecuteShow(ctx, "", false)
+		usedMinors, err := readUsedMinors()
 		if err != nil {
-			return 0, fmt.Errorf("querying show to find used minors: %w", err)
+			return 0, fmt.Errorf("reading used minors from sysfs: %w", err)
 		}
 
-		if err := advanceMinorPastUsed(resources); err != nil {
+		if err := advanceMinorPastUsed(usedMinors); err != nil {
 			return 0, err
 		}
 	}
@@ -112,41 +117,54 @@ func grabNextMinor() uint {
 	return minor
 }
 
-// advanceMinorPastUsed scans used minors from drbdsetup show output and
-// advances nextDeviceMinor past all of them. Called on minor collision.
-func advanceMinorPastUsed(resources []ShowResource) error {
+// readUsedMinors enumerates active DRBD minors by scanning /sys/block/drbd*.
+// Returns a sorted slice of minor numbers.
+func readUsedMinors() ([]uint, error) {
+	entries, err := os.ReadDir(SysBlockPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", SysBlockPath, err)
+	}
+
+	var minors []uint
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "drbd") {
+			continue
+		}
+		n, err := strconv.ParseUint(name[len("drbd"):], 10, 64)
+		if err != nil {
+			continue
+		}
+		minors = append(minors, uint(n))
+	}
+
+	slices.Sort(minors)
+	return minors, nil
+}
+
+// advanceMinorPastUsed advances nextDeviceMinor past all used minors.
+// usedMinors must be sorted in ascending order. Called on minor collision.
+func advanceMinorPastUsed(usedMinors []uint) error {
 	nextDeviceMinorMu.Lock()
 	defer nextDeviceMinorMu.Unlock()
 
-	var totalUsedMinors int
-	for _, res := range resources {
-		for _, vol := range res.ThisHost.Volumes {
-			totalUsedMinors++
-			nextDeviceMinor = max(nextDeviceMinor, uint(vol.DeviceMinor)+1)
-		}
-	}
-
-	if totalUsedMinors > MaxDeviceMinor {
+	if len(usedMinors) > MaxDeviceMinor {
 		return ErrNewMinorNoFreeMinor
 	}
 
+	if len(usedMinors) > 0 {
+		nextDeviceMinor = max(nextDeviceMinor, usedMinors[len(usedMinors)-1]+1)
+	}
+
 	if nextDeviceMinor > MaxDeviceMinor {
+		// Wrapped past the maximum — scan from 0 to find the first gap.
 		nextDeviceMinor = 0
 
-		if len(resources) > 0 {
-			usedMinors := make([]uint, 0, totalUsedMinors)
-			for _, res := range resources {
-				for _, vol := range res.ThisHost.Volumes {
-					usedMinors = append(usedMinors, uint(vol.DeviceMinor))
-				}
-			}
-			slices.Sort(usedMinors)
-			for _, m := range usedMinors {
-				if m > nextDeviceMinor {
-					return nil
-				} else if m == nextDeviceMinor {
-					nextDeviceMinor++
-				}
+		for _, m := range usedMinors {
+			if m > nextDeviceMinor {
+				return nil
+			} else if m == nextDeviceMinor {
+				nextDeviceMinor++
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Replace `drbdsetup show --json` (all resources) with a `/sys/block/drbd*` directory scan when detecting used minors during auto-allocation in `ExecuteNewAutoMinor`.

Changes in `images/agent/pkg/drbdutils/minor.go`:
- Add `readUsedMinors()` — enumerates `/sys/block/drbd*` entries to discover active DRBD minors via a single `ReadDir` call.
- Refactor `advanceMinorPastUsed()` to accept a sorted `[]uint` directly instead of `[]ShowResource`, eliminating the nested volume traversal.
- `ExecuteNewAutoMinor` collision-recovery path now calls `readUsedMinors()` instead of `ExecuteShow(ctx, "", false)`.

Changes in `images/agent/pkg/drbdutils/commands_test.go`:
- The "auto minor retries" test uses a temp directory with a `drbd0` subdirectory to simulate sysfs, replacing the fake `drbdsetup show` command and JSON fixture.

## Why do we need it, and what problem does it solve?

When `ExecuteNewAutoMinor` encounters a minor collision, it needs to discover which minors are already in use. The previous approach ran `drbdsetup show --json` for **all** resources — spawning a subprocess, having the DRBD kernel module serialize every resource's full configuration to JSON, and then parsing that potentially large blob in Go — all just to extract a list of `device_minor` integers.

The new approach reads `/sys/block/` directory entries. The DRBD kernel module creates `/sys/block/drbdN/` for each active device, so a single `os.ReadDir` call returns exactly the information needed with no subprocess overhead.

## What is the expected result?

- `ExecuteNewAutoMinor` continues to allocate free minors correctly, retrying on collision.
- On collision, no `drbdsetup show` subprocess is spawned; used minors are read from sysfs instead.
- No change in observable behavior — only the internal mechanism for discovering used minors is replaced.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.