### PR TITLE
fix(CI): fix checkout version in CVE scans

### DIFF
--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -99,7 +99,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v11
+      - uses: actions/checkout@v4
       - name: Split repository name
         id: split
         env:


### PR DESCRIPTION
## Description
Pin `actions/checkout` to `v4` in `.github/workflows/trivy_image_check.yaml`. The scheduled `cve_scan` job referenced a non-existent `actions/checkout@v11`, while the `cve_scan_on_pr` job already uses `@v4`. This brings both jobs in line.

## Why do we need it, and what problem does it solve?
`actions/checkout@v11` does not exist (latest stable is `v4`), so the scheduled CVE scan job fails to resolve the action and the workflow run breaks. Pinning to `v4` restores the regular CVE scan.

## What is the expected result?
The `cve_scan` job in `.github/workflows/trivy_image_check.yaml` resolves `actions/checkout@v4` and proceeds to subsequent steps (vault secrets import and `deckhouse/modules-actions/cve_scan@main`) as before.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
