### PR TITLE
[cis] Fix RVA deletion race causing attach timeouts

### DIFF
--- a/images/csi-driver/driver/controller.go
+++ b/images/csi-driver/driver/controller.go
@@ -215,9 +215,21 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, request *csi.Contr
 
 	d.log.Info(fmt.Sprintf("[ControllerPublishVolume][traceID:%s][volumeID:%s][nodeID:%s] Creating ReplicatedVolumeAttachment and waiting for Ready=true", traceID, volumeID, nodeID))
 
-	_, err := utils.EnsureRVA(ctx, d.cl, d.log, traceID, volumeID, nodeID)
+	// EnsureRVA may block waiting for a stale RVA (from a just-finished
+	// ControllerUnpublishVolume) to be fully finalized by rv-controller.
+	// Bound that wait to waitActionTimeout so the gRPC call does not hang
+	// if something is genuinely stuck: external-attacher will retry with backoff.
+	ensureCtx, ensureCancel := context.WithTimeout(ctx, d.waitActionTimeout)
+	_, err := utils.EnsureRVA(ensureCtx, d.cl, d.log, traceID, volumeID, nodeID)
+	ensureCancel()
 	if err != nil {
 		d.log.Error(err, fmt.Sprintf("[ControllerPublishVolume][traceID:%s][volumeID:%s][nodeID:%s] Failed to create ReplicatedVolumeAttachment", traceID, volumeID, nodeID))
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, status.Errorf(codes.DeadlineExceeded, "Timed out ensuring ReplicatedVolumeAttachment: %v", err)
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, status.Errorf(codes.Canceled, "Canceled ensuring ReplicatedVolumeAttachment: %v", err)
+		}
 		return nil, status.Errorf(codes.Internal, "Failed to create ReplicatedVolumeAttachment: %v", err)
 	}
 
@@ -285,14 +297,24 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, request *csi.Con
 		return nil, status.Errorf(codes.Internal, "Failed to delete ReplicatedVolumeAttachment: %v", err)
 	}
 
-	d.log.Info(fmt.Sprintf("[ControllerUnpublishVolume][traceID:%s][volumeID:%s][nodeID:%s] Waiting for node to disappear from status.actuallyAttachedTo", traceID, volumeID, nodeID))
-
-	unpublishWaitCtx, unpublishWaitCancel := context.WithTimeout(ctx, d.waitActionTimeout)
-	defer unpublishWaitCancel()
-	err = utils.WaitForAttachedToRemoved(unpublishWaitCtx, d.cl, d.log, traceID, volumeID, nodeID)
-	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[ControllerUnpublishVolume][traceID:%s][volumeID:%s][nodeID:%s] Failed to wait for status.actuallyAttachedTo removal", traceID, volumeID, nodeID))
-		return nil, status.Errorf(codes.Internal, "Failed to wait for status.actuallyAttachedTo removal: %v", err)
+	// Wait for the RVA object to be fully gone before returning OK.
+	// rv.status.actuallyAttachedTo is no longer populated by the controller
+	// (see api/v1alpha1/rv_types.go: ActuallyAttachedTo TODO), so we rely
+	// solely on the RVA lifecycle here. Returning OK while the RVA still
+	// carries the rv-controller finalizer would let external-attacher delete
+	// the VolumeAttachment while the next ControllerPublishVolume still
+	// observes a stale RVA with DeletionTimestamp, leading to
+	// "volume attachment is being deleted" / attach timeouts on rapidly
+	// cycling pods.
+	d.log.Info(fmt.Sprintf("[ControllerUnpublishVolume][traceID:%s][volumeID:%s][nodeID:%s] Waiting for ReplicatedVolumeAttachment object to be fully deleted", traceID, volumeID, nodeID))
+	rvaDelCtx, rvaDelCancel := context.WithTimeout(ctx, d.waitActionTimeout)
+	defer rvaDelCancel()
+	if err := utils.WaitForRVADeleted(rvaDelCtx, d.cl, d.log, traceID, volumeID, nodeID); err != nil {
+		d.log.Error(err, fmt.Sprintf("[ControllerUnpublishVolume][traceID:%s][volumeID:%s][nodeID:%s] Failed to wait for RVA deletion", traceID, volumeID, nodeID))
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, status.Errorf(codes.DeadlineExceeded, "Timed out waiting for RVA deletion: %v", err)
+		}
+		return nil, status.Errorf(codes.Internal, "Failed to wait for RVA deletion: %v", err)
 	}
 
 	d.log.Info(fmt.Sprintf("[ControllerUnpublishVolume][traceID:%s][volumeID:%s][nodeID:%s] Volume detached successfully", traceID, volumeID, nodeID))

--- a/images/csi-driver/driver/controller_test.go
+++ b/images/csi-driver/driver/controller_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver //nolint:revive
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+	"github.com/deckhouse/sds-replicated-volume/images/csi-driver/internal"
+	"github.com/deckhouse/sds-replicated-volume/images/csi-driver/pkg/utils"
+	"github.com/deckhouse/sds-replicated-volume/lib/go/common/logger"
+)
+
+const testStuckFinalizer = "test.deckhouse.io/stuck"
+
+func newTestDriver(t *testing.T, cl client.Client, timeout time.Duration) *Driver {
+	t.Helper()
+	log, err := logger.NewLogger("3")
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	return &Driver{
+		cl:                cl,
+		log:               log,
+		waitActionTimeout: timeout,
+		inFlight:          internal.NewInFlight(),
+	}
+}
+
+func newTestFakeClient() client.Client {
+	s := scheme.Scheme
+	_ = metav1.AddMetaToScheme(s)
+	_ = v1alpha1.AddToScheme(s)
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&v1alpha1.ReplicatedVolumeAttachment{}, &v1alpha1.ReplicatedVolume{}).
+		Build()
+}
+
+// Sanity-check that ControllerUnpublishVolume does not return OK until the RVA
+// object itself is fully deleted (simulates rv-controller holding its own
+// finalizer for a while after DeleteRVA is issued).
+func TestControllerUnpublishVolume_WaitsForRVADeletion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "vol-x"
+	nodeID := "node-1"
+	rvaName := utils.BuildRVAName(volumeID, nodeID)
+
+	cl := newTestFakeClient()
+
+	// RVA that still carries a non-CSI finalizer (mimics rv-controller finalizer).
+	rva := &v1alpha1.ReplicatedVolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       rvaName,
+			Finalizers: []string{testStuckFinalizer, utils.SDSReplicatedVolumeCSIFinalizer},
+		},
+		Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
+			ReplicatedVolumeName: volumeID,
+			NodeName:             nodeID,
+		},
+	}
+	if err := cl.Create(ctx, rva); err != nil {
+		t.Fatalf("create rva: %v", err)
+	}
+
+	d := newTestDriver(t, cl, 5*time.Second)
+
+	// Remove the stuck finalizer after a short delay so the RVA can actually
+	// disappear. Without this, ControllerUnpublishVolume should eventually
+	// time out instead of returning OK.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(200 * time.Millisecond)
+		cur := &v1alpha1.ReplicatedVolumeAttachment{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: rvaName}, cur); err != nil {
+			t.Errorf("unexpected get err: %v", err)
+			return
+		}
+		cur.Finalizers = nil
+		if err := cl.Update(ctx, cur); err != nil {
+			t.Errorf("unexpected update err: %v", err)
+		}
+	}()
+
+	start := time.Now()
+	_, err := d.ControllerUnpublishVolume(ctx, &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   nodeID,
+	})
+	<-done
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("ControllerUnpublishVolume: unexpected error: %v", err)
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("ControllerUnpublishVolume returned too fast (%s); expected to wait for RVA deletion", elapsed)
+	}
+
+	got := &v1alpha1.ReplicatedVolumeAttachment{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: rvaName}, got); err == nil {
+		t.Fatalf("RVA %s still present after ControllerUnpublishVolume", rvaName)
+	}
+}
+
+// When the rv-controller finalizer is never removed, ControllerUnpublishVolume
+// must surface DeadlineExceeded rather than returning OK too early or hanging.
+func TestControllerUnpublishVolume_ReturnsDeadlineExceededIfRVAStuck(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "vol-x"
+	nodeID := "node-1"
+	rvaName := utils.BuildRVAName(volumeID, nodeID)
+
+	cl := newTestFakeClient()
+
+	rva := &v1alpha1.ReplicatedVolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       rvaName,
+			Finalizers: []string{testStuckFinalizer, utils.SDSReplicatedVolumeCSIFinalizer},
+		},
+		Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
+			ReplicatedVolumeName: volumeID,
+			NodeName:             nodeID,
+		},
+	}
+	if err := cl.Create(ctx, rva); err != nil {
+		t.Fatalf("create rva: %v", err)
+	}
+
+	d := newTestDriver(t, cl, 300*time.Millisecond)
+
+	_, err := d.ControllerUnpublishVolume(ctx, &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   nodeID,
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.DeadlineExceeded {
+		t.Fatalf("expected codes.DeadlineExceeded, got %s: %v", st.Code(), err)
+	}
+}

--- a/images/csi-driver/driver/driver.go
+++ b/images/csi-driver/driver/driver.go
@@ -46,7 +46,7 @@ const (
 	// DefaultAddress is the default address that the csi plugin will serve its
 	// http handler on.
 	DefaultAddress           = "127.0.0.1:12302"
-	defaultWaitActionTimeout = 5 * time.Minute
+	defaultWaitActionTimeout = 1 * time.Minute
 )
 
 var (

--- a/images/csi-driver/pkg/utils/func.go
+++ b/images/csi-driver/pkg/utils/func.go
@@ -357,32 +357,10 @@ func GetDevicePathFromRVA(ctx context.Context, kc client.Client, volumeName, nod
 	return rva.Status.DevicePath, nil
 }
 
-func EnsureRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceID, volumeName, nodeName string) (string, error) {
+// createRVA creates a fresh ReplicatedVolumeAttachment with the CSI finalizer.
+// Treats AlreadyExists as success (another caller won the race).
+func createRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceID, volumeName, nodeName string) (string, error) {
 	rvaName := BuildRVAName(volumeName, nodeName)
-
-	existing := &srv.ReplicatedVolumeAttachment{}
-	if err := kc.Get(ctx, client.ObjectKey{Name: rvaName}, existing); err == nil {
-		// Validate it matches the intended binding.
-		if existing.Spec.ReplicatedVolumeName != volumeName || existing.Spec.NodeName != nodeName {
-			return "", fmt.Errorf("ReplicatedVolumeAttachment %s already exists but has different spec (volume=%s,node=%s)",
-				rvaName, existing.Spec.ReplicatedVolumeName, existing.Spec.NodeName,
-			)
-		}
-		if existing.DeletionTimestamp != nil {
-			return "", fmt.Errorf("ReplicatedVolumeAttachment %s is being deleted (phase=%s); cannot publish volume until deletion completes",
-				rvaName, existing.Status.Phase)
-		}
-		if !slices.Contains(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer) {
-			existing.Finalizers = append(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer)
-			if err := kc.Update(ctx, existing); err != nil {
-				return "", fmt.Errorf("add finalizer to ReplicatedVolumeAttachment %s: %w", rvaName, err)
-			}
-			log.Info(fmt.Sprintf("[EnsureRVA][traceID:%s][volumeID:%s][node:%s] Added finalizer to existing RVA %s", traceID, volumeName, nodeName, rvaName))
-		}
-		return rvaName, nil
-	} else if client.IgnoreNotFound(err) != nil {
-		return "", fmt.Errorf("get ReplicatedVolumeAttachment %s: %w", rvaName, err)
-	}
 
 	rva := &srv.ReplicatedVolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -395,12 +373,53 @@ func EnsureRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceI
 		},
 	}
 
-	log.Info(fmt.Sprintf("[EnsureRVA][traceID:%s][volumeID:%s][node:%s] Creating ReplicatedVolumeAttachment %s", traceID, volumeName, nodeName, rvaName))
+	log.Info(fmt.Sprintf("[createRVA][traceID:%s][volumeID:%s][node:%s] Creating ReplicatedVolumeAttachment %s", traceID, volumeName, nodeName, rvaName))
 	if err := kc.Create(ctx, rva); err != nil {
 		if kerrors.IsAlreadyExists(err) {
 			return rvaName, nil
 		}
 		return "", fmt.Errorf("create ReplicatedVolumeAttachment %s: %w", rvaName, err)
+	}
+	return rvaName, nil
+}
+
+func EnsureRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceID, volumeName, nodeName string) (string, error) {
+	rvaName := BuildRVAName(volumeName, nodeName)
+
+	existing := &srv.ReplicatedVolumeAttachment{}
+	err := kc.Get(ctx, client.ObjectKey{Name: rvaName}, existing)
+	if kerrors.IsNotFound(err) {
+		return createRVA(ctx, kc, log, traceID, volumeName, nodeName)
+	}
+	if err != nil {
+		return "", fmt.Errorf("get ReplicatedVolumeAttachment %s: %w", rvaName, err)
+	}
+
+	if existing.Spec.ReplicatedVolumeName != volumeName || existing.Spec.NodeName != nodeName {
+		return "", fmt.Errorf("ReplicatedVolumeAttachment %s already exists but has different spec (volume=%s,node=%s)",
+			rvaName, existing.Spec.ReplicatedVolumeName, existing.Spec.NodeName,
+		)
+	}
+
+	if existing.DeletionTimestamp != nil {
+		// Stale RVA from a previous attachment is still being finalized
+		// (typically by rv-controller holding RVControllerFinalizer).
+		// Wait for it to fully disappear within the parent ctx deadline,
+		// then create a fresh one.
+		log.Info(fmt.Sprintf("[EnsureRVA][traceID:%s][volumeID:%s][node:%s] Existing RVA %s has DeletionTimestamp (phase=%s, finalizers=%v); waiting for deletion to complete",
+			traceID, volumeName, nodeName, rvaName, existing.Status.Phase, existing.Finalizers))
+		if werr := WaitForRVADeleted(ctx, kc, log, traceID, volumeName, nodeName); werr != nil {
+			return "", fmt.Errorf("wait for stale ReplicatedVolumeAttachment %s deletion: %w", rvaName, werr)
+		}
+		return createRVA(ctx, kc, log, traceID, volumeName, nodeName)
+	}
+
+	if !slices.Contains(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer) {
+		existing.Finalizers = append(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer)
+		if uerr := kc.Update(ctx, existing); uerr != nil {
+			return "", fmt.Errorf("add finalizer to ReplicatedVolumeAttachment %s: %w", rvaName, uerr)
+		}
+		log.Info(fmt.Sprintf("[EnsureRVA][traceID:%s][volumeID:%s][node:%s] Added finalizer to existing RVA %s", traceID, volumeName, nodeName, rvaName))
 	}
 	return rvaName, nil
 }
@@ -619,96 +638,51 @@ func WaitForRVAReady(
 	}
 }
 
-// WaitForAttachedToProvided waits for a node name to appear in rv.status.actuallyAttachedTo
-func WaitForAttachedToProvided(
+// WaitForRVADeleted polls the ReplicatedVolumeAttachment object until it is
+// fully gone from the API (kerrors.IsNotFound). The RVA may still carry the
+// rv-controller finalizer after DeleteRVA has been issued; returning OK to
+// external-attacher before the RVA is fully deleted opens a race window where
+// the next ControllerPublishVolume on the same (volume,node) pair observes a
+// stale RVA with DeletionTimestamp and fails.
+func WaitForRVADeleted(
 	ctx context.Context,
 	kc client.Client,
 	log *logger.Logger,
 	traceID, volumeName, nodeName string,
 ) error {
+	rvaName := BuildRVAName(volumeName, nodeName)
 	var attemptCounter int
-	log.Info(fmt.Sprintf("[WaitForAttachedToProvided][traceID:%s][volumeID:%s][node:%s] Waiting for node to appear in status.actuallyAttachedTo", traceID, volumeName, nodeName))
+	var lastFinalizers []string
+	var lastPhase string
+	log.Info(fmt.Sprintf("[WaitForRVADeleted][traceID:%s][volumeID:%s][node:%s] Waiting for ReplicatedVolumeAttachment %s to be fully deleted", traceID, volumeName, nodeName, rvaName))
 	for {
 		attemptCounter++
-		select {
-		case <-ctx.Done():
-			log.Warning(fmt.Sprintf("[WaitForAttachedToProvided][traceID:%s][volumeID:%s][node:%s] context done", traceID, volumeName, nodeName))
-			return ctx.Err()
-		default:
-			time.Sleep(500 * time.Millisecond)
+		if err := ctx.Err(); err != nil {
+			log.Warning(fmt.Sprintf("[WaitForRVADeleted][traceID:%s][volumeID:%s][node:%s] context done after %d attempts; last finalizers=%v phase=%q: %v", traceID, volumeName, nodeName, attemptCounter, lastFinalizers, lastPhase, err))
+			return fmt.Errorf("wait for RVA %s deletion: last finalizers=%v phase=%q: %w", rvaName, lastFinalizers, lastPhase, err)
 		}
 
-		rv, err := GetReplicatedVolume(ctx, kc, volumeName)
+		rva := &srv.ReplicatedVolumeAttachment{}
+		err := kc.Get(ctx, client.ObjectKey{Name: rvaName}, rva)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
-				return fmt.Errorf("ReplicatedVolume %s not found", volumeName)
-			}
-			return err
-		}
-
-		if attemptCounter%10 == 0 {
-			log.Info(fmt.Sprintf("[WaitForAttachedToProvided][traceID:%s][volumeID:%s][node:%s] Attempt: %d, status.actuallyAttachedTo: %v", traceID, volumeName, nodeName, attemptCounter, rv.Status.ActuallyAttachedTo))
-		}
-
-		// Check if node is in status.actuallyAttachedTo
-		for _, attachedNode := range rv.Status.ActuallyAttachedTo {
-			if attachedNode == nodeName {
-				log.Info(fmt.Sprintf("[WaitForAttachedToProvided][traceID:%s][volumeID:%s][node:%s] Node is now in status.actuallyAttachedTo", traceID, volumeName, nodeName))
+				log.Info(fmt.Sprintf("[WaitForRVADeleted][traceID:%s][volumeID:%s][node:%s] ReplicatedVolumeAttachment %s is fully deleted", traceID, volumeName, nodeName, rvaName))
 				return nil
 			}
+			return fmt.Errorf("get ReplicatedVolumeAttachment %s: %w", rvaName, err)
 		}
 
-		log.Trace(fmt.Sprintf("[WaitForAttachedToProvided][traceID:%s][volumeID:%s][node:%s] Attempt %d, node not in status.actuallyAttachedTo yet. Waiting...", traceID, volumeName, nodeName, attemptCounter))
+		lastFinalizers = append(lastFinalizers[:0], rva.Finalizers...)
+		lastPhase = string(rva.Status.Phase)
+
+		if attemptCounter%10 == 0 {
+			log.Info(fmt.Sprintf("[WaitForRVADeleted][traceID:%s][volumeID:%s][node:%s] Attempt: %d, still present (deletionTimestamp=%v finalizers=%v phase=%q)", traceID, volumeName, nodeName, attemptCounter, rva.DeletionTimestamp, lastFinalizers, lastPhase))
+		}
+
+		if err := sleepWithContext(ctx); err != nil {
+			log.Warning(fmt.Sprintf("[WaitForRVADeleted][traceID:%s][volumeID:%s][node:%s] context done while sleeping after %d attempts; last finalizers=%v phase=%q: %v", traceID, volumeName, nodeName, attemptCounter, lastFinalizers, lastPhase, err))
+			return fmt.Errorf("wait for RVA %s deletion: last finalizers=%v phase=%q: %w", rvaName, lastFinalizers, lastPhase, err)
+		}
 	}
 }
 
-// WaitForAttachedToRemoved waits for a node name to disappear from rv.status.actuallyAttachedTo
-func WaitForAttachedToRemoved(
-	ctx context.Context,
-	kc client.Client,
-	log *logger.Logger,
-	traceID, volumeName, nodeName string,
-) error {
-	var attemptCounter int
-	log.Info(fmt.Sprintf("[WaitForAttachedToRemoved][traceID:%s][volumeID:%s][node:%s] Waiting for node to disappear from status.actuallyAttachedTo", traceID, volumeName, nodeName))
-	for {
-		attemptCounter++
-		select {
-		case <-ctx.Done():
-			log.Warning(fmt.Sprintf("[WaitForAttachedToRemoved][traceID:%s][volumeID:%s][node:%s] context done", traceID, volumeName, nodeName))
-			return ctx.Err()
-		default:
-			time.Sleep(500 * time.Millisecond)
-		}
-
-		rv, err := GetReplicatedVolume(ctx, kc, volumeName)
-		if err != nil {
-			if kerrors.IsNotFound(err) {
-				// Volume deleted, consider it as removed
-				log.Info(fmt.Sprintf("[WaitForAttachedToRemoved][traceID:%s][volumeID:%s][node:%s] ReplicatedVolume not found, considering node as removed", traceID, volumeName, nodeName))
-				return nil
-			}
-			return err
-		}
-
-		if attemptCounter%10 == 0 {
-			log.Info(fmt.Sprintf("[WaitForAttachedToRemoved][traceID:%s][volumeID:%s][node:%s] Attempt: %d, status.actuallyAttachedTo: %v", traceID, volumeName, nodeName, attemptCounter, rv.Status.ActuallyAttachedTo))
-		}
-
-		// Check if node is NOT in status.actuallyAttachedTo
-		found := false
-		for _, attachedNode := range rv.Status.ActuallyAttachedTo {
-			if attachedNode == nodeName {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			log.Info(fmt.Sprintf("[WaitForAttachedToRemoved][traceID:%s][volumeID:%s][node:%s] Node is no longer in status.actuallyAttachedTo", traceID, volumeName, nodeName))
-			return nil
-		}
-
-		log.Trace(fmt.Sprintf("[WaitForAttachedToRemoved][traceID:%s][volumeID:%s][node:%s] Attempt %d, node still in status.actuallyAttachedTo. Waiting...", traceID, volumeName, nodeName, attemptCounter))
-	}
-}

--- a/images/csi-driver/pkg/utils/func_publish_test.go
+++ b/images/csi-driver/pkg/utils/func_publish_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -213,12 +212,14 @@ var _ = Describe("ReplicatedVolumeAttachment utils", func() {
 	})
 })
 
-var _ = Describe("WaitForAttachedToProvided", func() {
+var _ = Describe("WaitForRVADeleted", func() {
 	var (
 		cl      client.Client
 		log     logger.Logger
 		traceID string
 	)
+
+	const stuckFinalizer = "test.deckhouse.io/stuck"
 
 	BeforeEach(func() {
 		cl = newFakeClient()
@@ -226,83 +227,122 @@ var _ = Describe("WaitForAttachedToProvided", func() {
 		traceID = "test-trace-id"
 	})
 
-	Context("when node already in status.actuallyAttachedTo", func() {
-		It("should return immediately", func(ctx SpecContext) {
-			volumeName := "test-volume"
-			nodeName := "node-1"
-
-			rv := createTestReplicatedVolume(volumeName)
-			rv.Status.ActuallyAttachedTo = []string{nodeName}
-			Expect(cl.Create(ctx, rv)).To(Succeed())
-
-			err := WaitForAttachedToProvided(ctx, cl, &log, traceID, volumeName, nodeName)
+	Context("when RVA does not exist", func() {
+		It("should return immediately without error", func(ctx SpecContext) {
+			err := WaitForRVADeleted(ctx, cl, &log, traceID, "missing-volume", "missing-node")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
-	Context("when node appears in status.actuallyAttachedTo", func() {
-		It("should wait and return successfully", func(ctx SpecContext) {
+	Context("when RVA is deleted in background", func() {
+		It("should wait and return successfully once the object is gone", func(ctx SpecContext) {
 			volumeName := "test-volume"
 			nodeName := "node-1"
+			rvaName := BuildRVAName(volumeName, nodeName)
 
-			rv := createTestReplicatedVolume(volumeName)
-			Expect(cl.Create(ctx, rv)).To(Succeed())
+			rva := &v1alpha1.ReplicatedVolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       rvaName,
+					Finalizers: []string{stuckFinalizer, SDSReplicatedVolumeCSIFinalizer},
+				},
+				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
+					ReplicatedVolumeName: volumeName,
+					NodeName:             nodeName,
+				},
+			}
+			Expect(cl.Create(ctx, rva)).To(Succeed())
 
-			// Update status in background after a short delay
+			// Delete sets DeletionTimestamp but keeps the object while the
+			// stuck finalizer is present (mimics rv-controller finalizer).
+			Expect(cl.Delete(ctx, rva)).To(Succeed())
+
 			go func() {
 				defer GinkgoRecover()
-				time.Sleep(100 * time.Millisecond)
-				updatedRV := &v1alpha1.ReplicatedVolume{}
-				Expect(cl.Get(ctx, client.ObjectKey{Name: volumeName}, updatedRV)).To(Succeed())
-				updatedRV.Status.ActuallyAttachedTo = []string{nodeName}
-				// Use Update instead of Status().Update for fake client
-				Expect(cl.Update(ctx, updatedRV)).To(Succeed())
+				time.Sleep(150 * time.Millisecond)
+				cur := &v1alpha1.ReplicatedVolumeAttachment{}
+				Expect(cl.Get(ctx, client.ObjectKey{Name: rvaName}, cur)).To(Succeed())
+				cur.Finalizers = nil
+				Expect(cl.Update(ctx, cur)).To(Succeed())
 			}()
 
-			// Use context with timeout to prevent hanging
-			timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			err := WaitForAttachedToProvided(timeoutCtx, cl, &log, traceID, volumeName, nodeName)
+			err := WaitForRVADeleted(waitCtx, cl, &log, traceID, volumeName, nodeName)
 			Expect(err).NotTo(HaveOccurred())
+
+			got := &v1alpha1.ReplicatedVolumeAttachment{}
+			getErr := cl.Get(ctx, client.ObjectKey{Name: rvaName}, got)
+			Expect(getErr).To(HaveOccurred())
 		})
 	})
 
-	Context("when ReplicatedVolume does not exist", func() {
-		It("should return an error", func(ctx SpecContext) {
-			volumeName := "non-existent-volume"
+	Context("when context deadline expires while RVA is stuck", func() {
+		It("should return a wrapped DeadlineExceeded error carrying diagnostics", func(ctx SpecContext) {
+			volumeName := "test-volume"
 			nodeName := "node-1"
+			rvaName := BuildRVAName(volumeName, nodeName)
 
-			err := WaitForAttachedToProvided(ctx, cl, &log, traceID, volumeName, nodeName)
+			rva := &v1alpha1.ReplicatedVolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       rvaName,
+					Finalizers: []string{stuckFinalizer},
+				},
+				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
+					ReplicatedVolumeName: volumeName,
+					NodeName:             nodeName,
+				},
+			}
+			Expect(cl.Create(ctx, rva)).To(Succeed())
+			Expect(cl.Delete(ctx, rva)).To(Succeed())
+
+			timeoutCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+			defer cancel()
+
+			err := WaitForRVADeleted(timeoutCtx, cl, &log, traceID, volumeName, nodeName)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("ReplicatedVolume"))
+			Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring(stuckFinalizer))
 		})
 	})
 
 	Context("when context is cancelled", func() {
-		It("should return context error", func(ctx SpecContext) {
+		It("should return a wrapped Canceled error", func(ctx SpecContext) {
 			volumeName := "test-volume"
 			nodeName := "node-1"
+			rvaName := BuildRVAName(volumeName, nodeName)
 
-			rv := createTestReplicatedVolume(volumeName)
-			Expect(cl.Create(ctx, rv)).To(Succeed())
+			rva := &v1alpha1.ReplicatedVolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       rvaName,
+					Finalizers: []string{stuckFinalizer},
+				},
+				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
+					ReplicatedVolumeName: volumeName,
+					NodeName:             nodeName,
+				},
+			}
+			Expect(cl.Create(ctx, rva)).To(Succeed())
+			Expect(cl.Delete(ctx, rva)).To(Succeed())
 
 			cancelledCtx, cancel := context.WithCancel(ctx)
 			cancel()
 
-			err := WaitForAttachedToProvided(cancelledCtx, cl, &log, traceID, volumeName, nodeName)
+			err := WaitForRVADeleted(cancelledCtx, cl, &log, traceID, volumeName, nodeName)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(context.Canceled))
+			Expect(errors.Is(err, context.Canceled)).To(BeTrue())
 		})
 	})
 })
 
-var _ = Describe("WaitForAttachedToRemoved", func() {
+var _ = Describe("EnsureRVA with stale deleting RVA", func() {
 	var (
 		cl      client.Client
 		log     logger.Logger
 		traceID string
 	)
+
+	const stuckFinalizer = "test.deckhouse.io/stuck"
 
 	BeforeEach(func() {
 		cl = newFakeClient()
@@ -310,87 +350,79 @@ var _ = Describe("WaitForAttachedToRemoved", func() {
 		traceID = "test-trace-id"
 	})
 
-	Context("when node already not in status.actuallyAttachedTo", func() {
-		It("should return immediately", func(ctx SpecContext) {
+	Context("when stale RVA gets deleted before the deadline", func() {
+		It("should wait for deletion and then create a fresh RVA", func(ctx SpecContext) {
 			volumeName := "test-volume"
 			nodeName := "node-1"
+			rvaName := BuildRVAName(volumeName, nodeName)
 
-			rv := createTestReplicatedVolume(volumeName)
-			Expect(cl.Create(ctx, rv)).To(Succeed())
+			stale := &v1alpha1.ReplicatedVolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       rvaName,
+					Finalizers: []string{stuckFinalizer, SDSReplicatedVolumeCSIFinalizer},
+				},
+				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
+					ReplicatedVolumeName: volumeName,
+					NodeName:             nodeName,
+				},
+			}
+			Expect(cl.Create(ctx, stale)).To(Succeed())
+			Expect(cl.Delete(ctx, stale)).To(Succeed())
 
-			err := WaitForAttachedToRemoved(ctx, cl, &log, traceID, volumeName, nodeName)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Context("when node is removed from status.actuallyAttachedTo", func() {
-		It("should wait and return successfully", func(ctx SpecContext) {
-			volumeName := "test-volume"
-			nodeName := "node-1"
-
-			rv := createTestReplicatedVolume(volumeName)
-			rv.Status.ActuallyAttachedTo = []string{nodeName}
-			Expect(cl.Create(ctx, rv)).To(Succeed())
-
-			// Update status in background after a short delay
 			go func() {
 				defer GinkgoRecover()
-				time.Sleep(100 * time.Millisecond)
-				updatedRV := &v1alpha1.ReplicatedVolume{}
-				Expect(cl.Get(ctx, client.ObjectKey{Name: volumeName}, updatedRV)).To(Succeed())
-				updatedRV.Status.ActuallyAttachedTo = []string{}
-				// Use Update instead of Status().Update for fake client
-				Expect(cl.Update(ctx, updatedRV)).To(Succeed())
+				time.Sleep(150 * time.Millisecond)
+				cur := &v1alpha1.ReplicatedVolumeAttachment{}
+				Expect(cl.Get(ctx, client.ObjectKey{Name: rvaName}, cur)).To(Succeed())
+				cur.Finalizers = nil
+				Expect(cl.Update(ctx, cur)).To(Succeed())
 			}()
 
-			// Use context with timeout to prevent hanging
-			timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			ensureCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			err := WaitForAttachedToRemoved(timeoutCtx, cl, &log, traceID, volumeName, nodeName)
+			got, err := EnsureRVA(ensureCtx, cl, &log, traceID, volumeName, nodeName)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(rvaName))
+
+			fresh := &v1alpha1.ReplicatedVolumeAttachment{}
+			Expect(cl.Get(ctx, client.ObjectKey{Name: rvaName}, fresh)).To(Succeed())
+			Expect(fresh.DeletionTimestamp).To(BeNil())
+			Expect(fresh.Finalizers).To(ContainElement(SDSReplicatedVolumeCSIFinalizer))
 		})
 	})
 
-	Context("when ReplicatedVolume does not exist", func() {
-		It("should return nil (considered success)", func(ctx SpecContext) {
-			volumeName := "non-existent-volume"
-			nodeName := "node-1"
-
-			err := WaitForAttachedToRemoved(ctx, cl, &log, traceID, volumeName, nodeName)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Context("when status is empty", func() {
-		It("should return nil (considered success)", func(ctx SpecContext) {
+	Context("when stale RVA is stuck past the deadline", func() {
+		It("should return a DeadlineExceeded error instead of creating a new RVA", func(ctx SpecContext) {
 			volumeName := "test-volume"
 			nodeName := "node-1"
+			rvaName := BuildRVAName(volumeName, nodeName)
 
-			rv := createTestReplicatedVolume(volumeName)
-			rv.Status = v1alpha1.ReplicatedVolumeStatus{}
-			Expect(cl.Create(ctx, rv)).To(Succeed())
+			stale := &v1alpha1.ReplicatedVolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       rvaName,
+					Finalizers: []string{stuckFinalizer, SDSReplicatedVolumeCSIFinalizer},
+				},
+				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
+					ReplicatedVolumeName: volumeName,
+					NodeName:             nodeName,
+				},
+			}
+			Expect(cl.Create(ctx, stale)).To(Succeed())
+			Expect(cl.Delete(ctx, stale)).To(Succeed())
 
-			err := WaitForAttachedToRemoved(ctx, cl, &log, traceID, volumeName, nodeName)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
+			ensureCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+			defer cancel()
 
-	Context("when context is cancelled", func() {
-		It("should return context error", func(ctx SpecContext) {
-			volumeName := "test-volume"
-			nodeName := "node-1"
-
-			rv := createTestReplicatedVolume(volumeName)
-			rv.Status.ActuallyAttachedTo = []string{nodeName}
-			Expect(cl.Create(ctx, rv)).To(Succeed())
-
-			cancelledCtx, cancel := context.WithCancel(ctx)
-			cancel()
-
-			err := WaitForAttachedToRemoved(cancelledCtx, cl, &log, traceID, volumeName, nodeName)
+			_, err := EnsureRVA(ensureCtx, cl, &log, traceID, volumeName, nodeName)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(context.Canceled))
+			Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+
+			// Stale object is still present with its DeletionTimestamp;
+			// no second RVA has been created in its place.
+			got := &v1alpha1.ReplicatedVolumeAttachment{}
+			Expect(cl.Get(ctx, client.ObjectKey{Name: rvaName}, got)).To(Succeed())
+			Expect(got.DeletionTimestamp).NotTo(BeNil())
 		})
 	})
 })
@@ -408,17 +440,3 @@ func newFakeClient() client.Client {
 	return builder.Build()
 }
 
-func createTestReplicatedVolume(name string) *v1alpha1.ReplicatedVolume {
-	return &v1alpha1.ReplicatedVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1alpha1.ReplicatedVolumeSpec{
-			Size:                       resource.MustParse("1Gi"),
-			ReplicatedStorageClassName: "rsc",
-		},
-		Status: v1alpha1.ReplicatedVolumeStatus{
-			ActuallyAttachedTo: []string{},
-		},
-	}
-}


### PR DESCRIPTION
## Summary

Fixes a race between `ControllerUnpublishVolume` and a subsequent `ControllerPublishVolume`
for the same `(volume, node)` pair that surfaces on rapidly rotating workloads
(e.g. GitLab CI runners reusing the same PVC on the same node) as:

- `FailedAttachVolume ... timed out waiting for external-attacher`
- `AttachVolume.Attach failed ... volume attachment is being deleted`

### Root cause

`ControllerUnpublishVolume` returned `OK` as soon as the node disappeared from
`rv.status.actuallyAttachedTo`, while the `ReplicatedVolumeAttachment` (RVA)
object itself still carried the `rv-controller` finalizer. `external-attacher`
then deleted the `VolumeAttachment`, and the next `ControllerPublishVolume`
observed a stale RVA with `DeletionTimestamp` set and failed immediately,
bubbling up as the errors above.

Additionally, `rv.status.actuallyAttachedTo` is no longer populated by any
controller or agent in the current codebase — the field is flagged for removal
in `api/v1alpha1/rv_types.go` (`// TODO: Remove this field. It is no longer used
(except for CSI driver, which will use RVA objects instead).`) and historical
writers in `images/controller` were removed on refactor branches
(`vvoyt-scheduler-refactor`, `vvoyt-move-rsc-controller`). So the old wait
effectively returned immediately on every unpublish, which is exactly what
opened the race window for external-attacher.

## Changes

All changes are confined to `images/csi-driver`. No API, controller or agent
changes.

- **New helper `WaitForRVADeleted`** (`pkg/utils/func.go`): polls the RVA
  object until `kerrors.IsNotFound`, logs the last observed finalizers/phase
  every 10 attempts for diagnostics, and returns `ctx.Err()` wrapped with the
  last state on deadline/cancel.
- **`EnsureRVA` refactor** (`pkg/utils/func.go`): on encountering a stale RVA
  with `DeletionTimestamp` it now waits for full deletion (bounded by the
  parent `ctx`) and then recreates a fresh RVA, instead of returning an error.
  The creation path is extracted into a dedicated `createRVA` helper and
  `EnsureRVA` itself is rewritten with early returns for clarity (no
  `switch`/`else` nesting).
- **`ControllerPublishVolume`** (`driver/controller.go`): wraps `EnsureRVA` in
  a `waitActionTimeout` context and maps `DeadlineExceeded`/`Canceled` to the
  corresponding gRPC codes so external-attacher retries with proper backoff.
- **`ControllerUnpublishVolume`** (`driver/controller.go`): waits only for the
  RVA object to be fully gone (via `WaitForRVADeleted`). Reliance on
  `rv.status.actuallyAttachedTo` is removed, since nothing populates it in the
  current codebase; `DeadlineExceeded` propagates as `codes.DeadlineExceeded`
  so sidecars retry sanely.
- **`defaultWaitActionTimeout`** (`driver/driver.go`): lowered from `5m` to
  `1m` so genuinely stuck calls release the gRPC slot sooner and sidecars
  retry faster.
- **Dead code removed** (`pkg/utils/func.go`, `pkg/utils/func_publish_test.go`):
  - `WaitForAttachedToProvided` was declared but never called from the driver
    (only from its own unit tests);
  - `WaitForAttachedToRemoved` was called only from `ControllerUnpublishVolume`,
    which no longer needs it.
  Both helpers and their unit tests are dropped together with the now-unused
  `createTestReplicatedVolume` fixture.

## Tests

- **Unit**, `images/csi-driver/pkg/utils`:
  - `WaitForRVADeleted`: returns immediately when RVA is already gone, waits
    when the RVA disappears in the background, surfaces `ctx.Err()` on
    `DeadlineExceeded` and on explicit `Cancel`.
  - `EnsureRVA`: happy paths (create from scratch, idempotent on already-CSI
    finalizer) plus two new scenarios — a stale RVA that is eventually freed
    (succeeds by recreating a fresh RVA) and a stale RVA that stays stuck
    (surfaces the `ctx` error).
- **Driver sanity**, `images/csi-driver/driver/controller_test.go`:
  - `TestControllerUnpublishVolume_WaitsForRVADeletion`: with a non-CSI
    finalizer on the RVA, `ControllerUnpublishVolume` must not return OK until
    the finalizer is removed and the RVA actually disappears.
  - `TestControllerUnpublishVolume_ReturnsDeadlineExceededIfRVAStuck`: if the
    non-CSI finalizer is never removed, the call must surface
    `codes.DeadlineExceeded` (not `Internal`, not OK).
