### PR TITLE
[csi] Do not delete already-formed RV from CreateVolume

### DIFF
--- a/images/csi-driver/driver/controller.go
+++ b/images/csi-driver/driver/controller.go
@@ -27,7 +27,9 @@ import (
 	"google.golang.org/grpc/status"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	srv "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-replicated-volume/images/csi-driver/internal"
 	"github.com/deckhouse/sds-replicated-volume/images/csi-driver/pkg/utils"
 )
@@ -101,71 +103,122 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ReplicatedVolumeSpec: %+v", traceID, volumeID, rvSpec))
 
+	// buildResponse assembles the CSI CreateVolumeResponse from an observed RV.
+	// Falls back to the requested size when the RV status has not yet reported one.
+	buildResponse := func(rv *srv.ReplicatedVolume) *csi.CreateVolumeResponse {
+		capacityBytes := rvSize.Value()
+		if rv != nil && rv.Status.Size != nil {
+			capacityBytes = rv.Status.Size.Value()
+		}
+		volumeCtx := make(map[string]string, len(request.Parameters)+1)
+		for k, v := range request.Parameters {
+			volumeCtx[k] = v
+		}
+		volumeCtx[internal.ReplicatedVolumeNameKey] = volumeID
+		d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] Volume created successfully, capacity: %d. volumeCtx: %+v", traceID, volumeID, capacityBytes, volumeCtx))
+		return &csi.CreateVolumeResponse{
+			Volume: &csi.Volume{
+				CapacityBytes:      capacityBytes,
+				VolumeId:           request.Name,
+				VolumeContext:      volumeCtx,
+				ContentSource:      nil,
+				AccessibleTopology: nil,
+			},
+		}
+	}
+
+	// cleanupEarlyRVA best-effort removes the WFFC-selected RVA that was created
+	// upfront in this RPC. Used on all error paths below.
+	cleanupEarlyRVA := func() {
+		if !createdEarlyRVA {
+			return
+		}
+		if rvaErr := utils.DeleteRVA(ctx, d.cl, d.log, traceID, volumeID, preferredNode); rvaErr != nil {
+			d.log.Error(rvaErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s][node:%s] error cleaning up WFFC RVA", traceID, volumeID, preferredNode))
+		}
+	}
+
 	// Create ReplicatedVolume
 	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ------------ CreateReplicatedVolume start ------------", traceID, volumeID))
 	pvcName := request.Parameters[internal.PVCAnnotationNameKey]
 	pvcNamespace := request.Parameters[internal.PVCAnnotationNamespaceKey]
 	_, err := utils.CreateReplicatedVolume(ctx, d.cl, d.log, traceID, volumeID, pvcName, pvcNamespace, rvSpec)
-	if err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ReplicatedVolume %s already exists. Skip creating", traceID, volumeID, volumeID))
-		} else {
-			d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error CreateReplicatedVolume", traceID, volumeID))
-			if createdEarlyRVA {
-				if rvaErr := utils.DeleteRVA(ctx, d.cl, d.log, traceID, volumeID, preferredNode); rvaErr != nil {
-					d.log.Error(rvaErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s][node:%s] error cleaning up WFFC RVA", traceID, volumeID, preferredNode))
-				}
-			}
-			return nil, err
-		}
-	}
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ------------ CreateReplicatedVolume end ------------", traceID, volumeID))
 
-	// Wait for ReplicatedVolume to become ready
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] start wait ReplicatedVolume", traceID, volumeID))
-	waitCtx, waitCancel := context.WithTimeout(ctx, d.waitActionTimeout)
-	defer waitCancel()
-	rv, attemptCounter, err := utils.WaitForReplicatedVolumeReady(waitCtx, d.cl, d.log, traceID, volumeID)
-	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error WaitForReplicatedVolumeReady. Delete ReplicatedVolume %s", traceID, volumeID, volumeID))
-
-		deleteErr := utils.DeleteReplicatedVolume(ctx, d.cl, d.log, traceID, volumeID)
-		if deleteErr != nil {
-			d.log.Error(deleteErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error DeleteReplicatedVolume", traceID, volumeID))
-		}
-		if createdEarlyRVA {
-			if rvaErr := utils.DeleteRVA(ctx, d.cl, d.log, traceID, volumeID, preferredNode); rvaErr != nil {
-				d.log.Error(rvaErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s][node:%s] error cleaning up WFFC RVA", traceID, volumeID, preferredNode))
-			}
-		}
-
-		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error creating ReplicatedVolume", traceID, volumeID))
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error CreateReplicatedVolume", traceID, volumeID))
+		cleanupEarlyRVA()
 		return nil, err
 	}
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] finish wait ReplicatedVolume, attempt counter = %d", traceID, volumeID, attemptCounter))
 
-	capacityBytes := rvSize.Value()
-	if rv.Status.Size != nil {
-		capacityBytes = rv.Status.Size.Value()
+	if kerrors.IsAlreadyExists(err) {
+		d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ReplicatedVolume already exists; re-observing", traceID, volumeID))
+		existing := &srv.ReplicatedVolume{}
+		getErr := d.cl.Get(ctx, client.ObjectKey{Name: volumeID}, existing)
+		if getErr != nil {
+			d.log.Error(getErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] cannot observe existing ReplicatedVolume", traceID, volumeID))
+			cleanupEarlyRVA()
+			return nil, status.Errorf(codes.Unavailable, "cannot observe existing ReplicatedVolume %s: %v", volumeID, getErr)
+		}
+		if existing.DeletionTimestamp != nil {
+			d.log.Warning(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] existing ReplicatedVolume is being deleted (deletionTimestamp=%v)", traceID, volumeID, existing.DeletionTimestamp))
+			cleanupEarlyRVA()
+			return nil, status.Errorf(codes.Aborted, "ReplicatedVolume %s is being deleted", volumeID)
+		}
+		if utils.IsReplicatedVolumePastFormation(existing) {
+			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ReplicatedVolume already past Formation; returning success without Wait", traceID, volumeID))
+			return buildResponse(existing), nil
+		}
+		d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ReplicatedVolume exists but still forming (datameshRevision=%d); proceeding to wait for readiness", traceID, volumeID, existing.Status.DatameshRevision))
+	} else {
+		d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ReplicatedVolume created successfully. Proceeding to wait for readiness", traceID, volumeID))
 	}
 
-	volumeCtx := make(map[string]string, len(request.Parameters))
-	for k, v := range request.Parameters {
-		volumeCtx[k] = v
+	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ------------ CreateReplicatedVolume end ------------", traceID, volumeID))
+	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] start wait ReplicatedVolume", traceID, volumeID))
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, d.waitActionTimeout)
+	defer waitCancel()
+	rv, attemptCounter, waitErr := utils.WaitForReplicatedVolumeReady(waitCtx, d.cl, d.log, traceID, volumeID)
+	if waitErr != nil {
+		d.log.Error(waitErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error WaitForReplicatedVolumeReady", traceID, volumeID))
+
+		// Re-observe the RV to decide the outcome:
+		//   - PastFormation && no DeletionTimestamp  -> race win: rv-controller
+		//     committed Formation between Wait's last poll and this cleanup;
+		//     return Success and keep the early RVA (same as happy path).
+		//   - DeletionTimestamp != nil               -> someone else is deleting
+		//     the RV; skip our Delete to avoid fighting.
+		//   - Otherwise (RV missing / Get error / not past Formation)
+		//     -> RV is uncommitted garbage; delete it so the next CreateVolume
+		//     retry can recreate it cleanly.
+		observed := &srv.ReplicatedVolume{}
+		getErr := d.cl.Get(ctx, client.ObjectKey{Name: volumeID}, observed)
+		if getErr == nil && observed.DeletionTimestamp == nil && utils.IsReplicatedVolumePastFormation(observed) {
+			d.log.Warning(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] RV became past Formation (datameshRevision=%d) between Wait deadline and cleanup; returning success", traceID, volumeID, observed.Status.DatameshRevision))
+			return buildResponse(observed), nil
+		}
+
+		cleanupEarlyRVA()
+
+		switch {
+		case kerrors.IsNotFound(getErr):
+			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] RV already gone between Wait and cleanup; nothing to delete", traceID, volumeID))
+		case getErr != nil:
+			d.log.Warning(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] cannot observe RV for safe cleanup decision: %v; skipping delete", traceID, volumeID, getErr))
+		case observed.DeletionTimestamp != nil:
+			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] RV already being deleted; skipping delete", traceID, volumeID))
+		default:
+			if delErr := utils.DeleteReplicatedVolume(ctx, d.cl, d.log, traceID, volumeID); delErr != nil {
+				d.log.Error(delErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error DeleteReplicatedVolume", traceID, volumeID))
+			}
+		}
+
+		return nil, waitErr
 	}
-	volumeCtx[internal.ReplicatedVolumeNameKey] = volumeID
+	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ReplicatedVolume ready successfully, attempt counter: %d", traceID, volumeID, attemptCounter))
+	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ------------ WaitForReplicatedVolumeReady end ------------", traceID, volumeID))
 
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] Volume created successfully, capacity: %d. volumeCtx: %+v", traceID, volumeID, capacityBytes, volumeCtx))
-
-	return &csi.CreateVolumeResponse{
-		Volume: &csi.Volume{
-			CapacityBytes:      capacityBytes,
-			VolumeId:           request.Name,
-			VolumeContext:      volumeCtx,
-			ContentSource:      nil,
-			AccessibleTopology: nil,
-		},
-	}, nil
+	return buildResponse(rv), nil
 }
 
 func (d *Driver) DeleteVolume(ctx context.Context, request *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {

--- a/images/csi-driver/driver/controller_test.go
+++ b/images/csi-driver/driver/controller_test.go
@@ -18,6 +18,7 @@ package driver //nolint:revive
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-replicated-volume/images/csi-driver/internal"
@@ -170,5 +172,368 @@ func TestControllerUnpublishVolume_ReturnsDeadlineExceededIfRVAStuck(t *testing.
 	}
 	if st.Code() != codes.DeadlineExceeded {
 		t.Fatalf("expected codes.DeadlineExceeded, got %s: %v", st.Code(), err)
+	}
+}
+
+// --- CreateVolume scenarios ---------------------------------------------------
+
+// newCreateVolumeRequest builds a minimal valid CSI CreateVolumeRequest.
+func newCreateVolumeRequest(volumeID string) *csi.CreateVolumeRequest {
+	return &csi.CreateVolumeRequest{
+		Name: volumeID,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 << 30,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+				AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			},
+		},
+		Parameters: map[string]string{
+			internal.BindingModeKey:            internal.BindingModeI,
+			ReplicatedStorageClassParamNameKey: "rsc-x",
+		},
+	}
+}
+
+// createRVPastFormation pre-creates an RV and marks its status as past Formation.
+func createRVPastFormation(t *testing.T, ctx context.Context, cl client.Client, volumeID string) *v1alpha1.ReplicatedVolume {
+	t.Helper()
+	rv := &v1alpha1.ReplicatedVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       volumeID,
+			Finalizers: []string{utils.SDSReplicatedVolumeCSIFinalizer},
+		},
+	}
+	if err := cl.Create(ctx, rv); err != nil {
+		t.Fatalf("create RV: %v", err)
+	}
+	rv.Status.DatameshRevision = 1
+	if err := cl.Status().Update(ctx, rv); err != nil {
+		t.Fatalf("set RV status: %v", err)
+	}
+	return rv
+}
+
+// createRVStillForming pre-creates an RV with empty status so the predicate
+// IsReplicatedVolumePastFormation is false for it.
+func createRVStillForming(t *testing.T, ctx context.Context, cl client.Client, volumeID string) *v1alpha1.ReplicatedVolume {
+	t.Helper()
+	rv := &v1alpha1.ReplicatedVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       volumeID,
+			Finalizers: []string{utils.SDSReplicatedVolumeCSIFinalizer},
+		},
+	}
+	if err := cl.Create(ctx, rv); err != nil {
+		t.Fatalf("create RV: %v", err)
+	}
+	return rv
+}
+
+// formRVAsync marks the RV past Formation after a delay, letting the Wait loop observe it.
+func formRVAsync(t *testing.T, ctx context.Context, cl client.Client, volumeID string, after time.Duration) chan struct{} {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		timer := time.NewTimer(after)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		cur := &v1alpha1.ReplicatedVolume{}
+		for i := 0; i < 50; i++ {
+			if err := cl.Get(ctx, client.ObjectKey{Name: volumeID}, cur); err != nil {
+				time.Sleep(20 * time.Millisecond)
+				continue
+			}
+			cur.Status.DatameshRevision = 1
+			if err := cl.Status().Update(ctx, cur); err == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+	return done
+}
+
+// TestCreateVolume_AlreadyExists_PastFormation_ReturnsSuccessWithoutWait
+// ensures that CreateVolume returns Success immediately when the RV is
+// already past Formation, without entering the Wait loop.
+func TestCreateVolume_AlreadyExists_PastFormation_ReturnsSuccessWithoutWait(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	volumeID := "rv-already-formed"
+	cl := newTestFakeClient()
+	createRVPastFormation(t, ctx, cl, volumeID)
+
+	// waitActionTimeout is intentionally large. If we accidentally enter Wait,
+	// we still expect Wait to finish quickly because DatameshRevision>0 already,
+	// so we additionally assert that the call returns fast.
+	d := newTestDriver(t, cl, 5*time.Second)
+
+	start := time.Now()
+	resp, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("CreateVolume: unexpected error: %v", err)
+	}
+	if resp == nil || resp.Volume == nil || resp.Volume.VolumeId != volumeID {
+		t.Fatalf("CreateVolume: unexpected response: %+v", resp)
+	}
+	// Wait's polling interval is 500ms; a fast path avoids it entirely.
+	if elapsed > 400*time.Millisecond {
+		t.Fatalf("CreateVolume took too long (%s); expected fast path without Wait", elapsed)
+	}
+}
+
+// TestCreateVolume_AlreadyExists_StillForming_WaitSucceeds ensures that a
+// pre-existing RV that is still forming makes CreateVolume fall through into
+// the common Wait block, and Success is returned once Formation completes.
+func TestCreateVolume_AlreadyExists_StillForming_WaitSucceeds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "rv-forming-ok"
+	cl := newTestFakeClient()
+	createRVStillForming(t, ctx, cl, volumeID)
+
+	d := newTestDriver(t, cl, 5*time.Second)
+
+	done := formRVAsync(t, ctx, cl, volumeID, 300*time.Millisecond)
+
+	resp, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	<-done
+	if err != nil {
+		t.Fatalf("CreateVolume: unexpected error: %v", err)
+	}
+	if resp == nil || resp.Volume == nil || resp.Volume.VolumeId != volumeID {
+		t.Fatalf("CreateVolume: unexpected response: %+v", resp)
+	}
+}
+
+// TestCreateVolume_AlreadyExists_StillForming_WaitFails_DeletesGarbage ensures
+// that when we fall through into Wait for a pre-existing, still-forming RV and
+// Wait fails, the RV is garbage-collected. A not-past-Formation RV carries no
+// committed data and can be safely recreated on the next CreateVolume retry.
+func TestCreateVolume_AlreadyExists_StillForming_WaitFails_DeletesGarbage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "rv-forming-stuck"
+	cl := newTestFakeClient()
+	createRVStillForming(t, ctx, cl, volumeID)
+
+	d := newTestDriver(t, cl, 200*time.Millisecond)
+
+	_, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	if err == nil {
+		t.Fatalf("CreateVolume: expected error, got nil")
+	}
+
+	got := &v1alpha1.ReplicatedVolume{}
+	gerr := cl.Get(ctx, client.ObjectKey{Name: volumeID}, got)
+	if gerr == nil {
+		t.Fatalf("expected pre-existing still-forming RV to be deleted as garbage, but it still exists: %+v", got)
+	}
+}
+
+// TestCreateVolume_AlreadyExists_BeingDeleted_ReturnsAborted ensures that
+// CreateVolume returns codes.Aborted when the existing RV has a DeletionTimestamp.
+func TestCreateVolume_AlreadyExists_BeingDeleted_ReturnsAborted(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	volumeID := "rv-being-deleted"
+	cl := newTestFakeClient()
+	rv := createRVStillForming(t, ctx, cl, volumeID)
+	// Delete; fake client keeps the object around (finalizer) with DeletionTimestamp.
+	if err := cl.Delete(ctx, rv); err != nil {
+		t.Fatalf("delete rv: %v", err)
+	}
+
+	d := newTestDriver(t, cl, 200*time.Millisecond)
+
+	_, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	if err == nil {
+		t.Fatalf("CreateVolume: expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.Aborted {
+		t.Fatalf("expected codes.Aborted, got %s: %v", st.Code(), err)
+	}
+}
+
+// TestCreateVolume_FreshCreate_WaitSucceeds_ReturnsResponse verifies the
+// happy path: CreateVolume creates a new RV and returns Success after the
+// RV becomes past Formation.
+func TestCreateVolume_FreshCreate_WaitSucceeds_ReturnsResponse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "rv-fresh-ok"
+	cl := newTestFakeClient()
+
+	d := newTestDriver(t, cl, 5*time.Second)
+
+	done := formRVAsync(t, ctx, cl, volumeID, 300*time.Millisecond)
+
+	resp, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	<-done
+	if err != nil {
+		t.Fatalf("CreateVolume: unexpected error: %v", err)
+	}
+	if resp == nil || resp.Volume == nil || resp.Volume.VolumeId != volumeID {
+		t.Fatalf("CreateVolume: unexpected response: %+v", resp)
+	}
+}
+
+// TestCreateVolume_FreshCreate_WaitFails_NotPastFormation_DeletesGarbage
+// ensures that when CreateVolume creates the RV in this RPC and Wait fails,
+// the RV is garbage-collected because it has not been past Formation.
+func TestCreateVolume_FreshCreate_WaitFails_NotPastFormation_DeletesGarbage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "rv-fresh-garbage"
+	cl := newTestFakeClient()
+
+	d := newTestDriver(t, cl, 150*time.Millisecond)
+
+	_, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	if err == nil {
+		t.Fatalf("CreateVolume: expected error, got nil")
+	}
+
+	got := &v1alpha1.ReplicatedVolume{}
+	gerr := cl.Get(ctx, client.ObjectKey{Name: volumeID}, got)
+	if gerr == nil {
+		// DeleteReplicatedVolume removes the finalizer and calls Delete; on the
+		// fake client with no other finalizers the object is fully gone.
+		t.Fatalf("expected RV to be deleted, but it still exists: %+v", got)
+	}
+}
+
+// TestCreateVolume_WaitFails_RaceWin_ReturnsSuccess verifies that when Wait
+// returns an error but rv-controller actually committed Formation between
+// Wait's last poll and the post-Wait re-observe, CreateVolume returns Success
+// and does NOT delete the RV. Deterministically simulated via a Get
+// interceptor that flips the observed RV to past-Formation on the second Get.
+func TestCreateVolume_WaitFails_RaceWin_ReturnsSuccess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "rv-race-win"
+	s := scheme.Scheme
+	_ = metav1.AddMetaToScheme(s)
+	_ = v1alpha1.AddToScheme(s)
+
+	var rvGetCount atomic.Int32
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&v1alpha1.ReplicatedVolumeAttachment{}, &v1alpha1.ReplicatedVolume{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				// 1st Get of this RV: AlreadyExists re-observe (still-forming).
+				// 2nd+ Gets: post-Wait re-observe - flip to past-Formation.
+				if rv, ok := obj.(*v1alpha1.ReplicatedVolume); ok && key.Name == volumeID {
+					if rvGetCount.Add(1) >= 2 {
+						rv.Status.DatameshRevision = 1
+					}
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	createRVStillForming(t, ctx, cl, volumeID)
+
+	// waitActionTimeout=1ns forces Wait to return ctx.Err immediately in its
+	// first select iteration, without ever Get-ing the RV itself (otherwise
+	// Wait would see still-forming and loop until deadline).
+	d := newTestDriver(t, cl, 1*time.Nanosecond)
+	resp, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	if err != nil {
+		t.Fatalf("CreateVolume: expected success on race-win, got %v", err)
+	}
+	if resp == nil || resp.Volume == nil || resp.Volume.VolumeId != volumeID {
+		t.Fatalf("CreateVolume: unexpected response: %+v", resp)
+	}
+
+	got := &v1alpha1.ReplicatedVolume{}
+	if gerr := cl.Get(ctx, client.ObjectKey{Name: volumeID}, got); gerr != nil {
+		t.Fatalf("race-winning RV must remain, got error: %v", gerr)
+	}
+	if got.DeletionTimestamp != nil {
+		t.Fatalf("race-winning RV must not be deleted, but has DeletionTimestamp=%v", got.DeletionTimestamp)
+	}
+}
+
+// TestCreateVolume_FreshCreate_WaitFails_DeletionTimestamp_DoesNotDelete
+// ensures that if a racing actor issues Delete on the fresh RV during Wait,
+// CreateVolume observes the DeletionTimestamp and skips its own Delete.
+func TestCreateVolume_FreshCreate_WaitFails_DeletionTimestamp_DoesNotDelete(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	volumeID := "rv-fresh-race-delete"
+	cl := newTestFakeClient()
+
+	d := newTestDriver(t, cl, 5*time.Second)
+
+	// Attach a non-CSI finalizer shortly after Create, then issue Delete.
+	// The extra finalizer keeps the object around with a DeletionTimestamp so
+	// the post-Wait guard can observe it.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			cur := &v1alpha1.ReplicatedVolume{}
+			if err := cl.Get(ctx, client.ObjectKey{Name: volumeID}, cur); err == nil {
+				cur.Finalizers = append(cur.Finalizers, testStuckFinalizer)
+				if err := cl.Update(ctx, cur); err == nil {
+					_ = cl.Delete(ctx, cur)
+					return
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+
+	_, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
+	<-done
+	if err == nil {
+		t.Fatalf("CreateVolume: expected error, got nil")
+	}
+
+	got := &v1alpha1.ReplicatedVolume{}
+	if gerr := cl.Get(ctx, client.ObjectKey{Name: volumeID}, got); gerr != nil {
+		t.Fatalf("expected RV to remain (guard by DeletionTimestamp), got error: %v", gerr)
+	}
+	if got.DeletionTimestamp == nil {
+		t.Fatalf("expected RV to be in deleting state, got: %+v", got)
+	}
+	// CreateVolume must NOT have stripped the CSI finalizer as part of a Delete.
+	csiFinalizerFound := false
+	for _, f := range got.Finalizers {
+		if f == utils.SDSReplicatedVolumeCSIFinalizer {
+			csiFinalizerFound = true
+			break
+		}
+	}
+	if !csiFinalizerFound {
+		t.Fatalf("CSI finalizer must be preserved when CreateVolume skips Delete, finalizers=%v", got.Finalizers)
 	}
 }

--- a/images/csi-driver/pkg/utils/func.go
+++ b/images/csi-driver/pkg/utils/func.go
@@ -85,6 +85,21 @@ func hasFormationTransition(transitions []srv.ReplicatedVolumeDatameshTransition
 	return false
 }
 
+// IsReplicatedVolumePastFormation reports whether the RV has completed its
+// initial Formation transition. This is the inverse of rv-controller's
+// isFormationInProgress predicate.
+//
+// Monotonicity: DatameshRevision grows monotonically during normal operation
+// and is only reset to 0 by reconcileFormationRestartIfTimeoutPassed in the
+// rv-controller. That restart path only runs while the RV is already in an
+// active Formation transition (i.e. while this predicate is already false).
+// Therefore the predicate transitions false -> true exactly once per RV and
+// stays true for the remainder of the RV's lifetime. This makes it a safe
+// "formation committed" marker for cleanup decisions in CreateVolume.
+func IsReplicatedVolumePastFormation(rv *srv.ReplicatedVolume) bool {
+	return rv != nil && rv.Status.DatameshRevision > 0 && !hasFormationTransition(rv.Status.DatameshTransitions)
+}
+
 // WaitForReplicatedVolumeReady waits for ReplicatedVolume to become ready
 // and returns the last-fetched RV on success.
 func WaitForReplicatedVolumeReady(
@@ -118,7 +133,7 @@ func WaitForReplicatedVolumeReady(
 			return nil, attemptCounter, fmt.Errorf("failed to create ReplicatedVolume %s, reason: ReplicatedVolume is being deleted", name)
 		}
 
-		if rv.Status.DatameshRevision > 0 && !hasFormationTransition(rv.Status.DatameshTransitions) {
+		if IsReplicatedVolumePastFormation(rv) {
 			log.Info(fmt.Sprintf("[WaitForReplicatedVolumeReady][traceID:%s][volumeID:%s] ReplicatedVolume is ready (datameshRevision=%d, no Formation transition)", traceID, name, rv.Status.DatameshRevision))
 			return rv, attemptCounter, nil
 		}

--- a/images/csi-driver/pkg/utils/func_test.go
+++ b/images/csi-driver/pkg/utils/func_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils //nolint:revive
+
+import (
+	"testing"
+
+	srv "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+)
+
+func TestIsReplicatedVolumePastFormation(t *testing.T) {
+	tests := []struct {
+		name string
+		rv   *srv.ReplicatedVolume
+		want bool
+	}{
+		{
+			name: "nil RV",
+			rv:   nil,
+			want: false,
+		},
+		{
+			name: "zero DatameshRevision and no transitions",
+			rv:   &srv.ReplicatedVolume{},
+			want: false,
+		},
+		{
+			name: "zero DatameshRevision with Formation transition",
+			rv: &srv.ReplicatedVolume{
+				Status: srv.ReplicatedVolumeStatus{
+					DatameshRevision: 0,
+					DatameshTransitions: []srv.ReplicatedVolumeDatameshTransition{
+						{Type: srv.ReplicatedVolumeDatameshTransitionTypeFormation},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "revision>0 with Formation transition still in progress",
+			rv: &srv.ReplicatedVolume{
+				Status: srv.ReplicatedVolumeStatus{
+					DatameshRevision: 1,
+					DatameshTransitions: []srv.ReplicatedVolumeDatameshTransition{
+						{Type: srv.ReplicatedVolumeDatameshTransitionTypeFormation},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "revision>0 and no Formation transition",
+			rv: &srv.ReplicatedVolume{
+				Status: srv.ReplicatedVolumeStatus{
+					DatameshRevision: 1,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "revision>0 with unrelated transition (AddReplica)",
+			rv: &srv.ReplicatedVolume{
+				Status: srv.ReplicatedVolumeStatus{
+					DatameshRevision: 5,
+					DatameshTransitions: []srv.ReplicatedVolumeDatameshTransition{
+						{Type: srv.ReplicatedVolumeDatameshTransitionTypeAddReplica},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "revision>0 with AddReplica and Formation mixed (still forming)",
+			rv: &srv.ReplicatedVolume{
+				Status: srv.ReplicatedVolumeStatus{
+					DatameshRevision: 5,
+					DatameshTransitions: []srv.ReplicatedVolumeDatameshTransition{
+						{Type: srv.ReplicatedVolumeDatameshTransitionTypeAddReplica},
+						{Type: srv.ReplicatedVolumeDatameshTransitionTypeFormation},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsReplicatedVolumePastFormation(tc.rv); got != tc.want {
+				t.Fatalf("IsReplicatedVolumePastFormation = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`CreateVolume` unconditionally ran `DeleteReplicatedVolume` on any `WaitForReplicatedVolumeReady` error. Any transient wait failure (RPC deadline, apiserver hiccup, informer lag) on a retry for an already-formed RV would destroy a healthy volume. Retries of this kind can come from in-flight CSI retries on a Pending PVC, provisioner/csi-driver restarts mid-Provision, or DR flows (etcd/Velero restore) where a PVC is re-queued while the backing RV is already past Formation.

## Fix

Use a monotonic marker `utils.IsReplicatedVolumePastFormation` (`DatameshRevision > 0` and no Formation transition) — exported and reused in `WaitForReplicatedVolumeReady`.

`CreateVolume` flow:
- **AlreadyExists**: re-observe once.
  - past-Formation → Success (no Wait, no Delete).
  - `DeletionTimestamp` → `Aborted`.
  - Get error → `Unavailable`.
  - still forming → fall into common Wait.
- **Fresh-create**: fall into common Wait.
- **Wait failure**: re-observe and decide.
  - past-Formation && no `DeletionTimestamp` → **race win**: return Success, keep the early RVA (like happy path).
  - `DeletionTimestamp` → skip Delete (someone else is deleting).
  - NotFound → nothing to delete.
  - Get error → skip Delete (cannot decide safely).
  - otherwise → uncommitted garbage; Delete so the next retry can recreate cleanly.

WFFC-selected early RVA is cleaned up on all error-returning paths.

## Tests

- Unit tests for `IsReplicatedVolumePastFormation`.
- Driver-level tests for every `CreateVolume` branch: AlreadyExists (past-formation fast path, still-forming wait-ok, still-forming wait-fail deletes garbage, being-deleted → Aborted), fresh-create (happy path, wait-fail GC, DeletionTimestamp race preserves RV), and the race-win case (deterministic via Get interceptor) that returns Success without deleting.