### PR TITLE
[werf] Expose DistroPackagesProxy and proxy envs at root

### DIFF
--- a/.werf/images.yaml
+++ b/.werf/images.yaml
@@ -1,7 +1,8 @@
 {{- $ImagesBuildFiles := .Files.Glob "images/*/{Dockerfile,werf.inc.yaml}" }}
+{{- $Root := . }}
 
 {{- range $path, $content := $ImagesBuildFiles  }}
-  {{ $ctx := (dict "ImageName" ($path | split "/")._1 "Root" $ "Versions" $.VERSIONS "Files" $.Files) }}
+  {{- $ctx := dict "ImageName" ($path | split "/")._1 "Root" $Root "Versions" $Root.VERSIONS "Files" $Root.Files "SOURCE_REPO" $Root.SOURCE_REPO "GOPROXY" $Root.GOPROXY "DistroPackagesProxy" $Root.DistroPackagesProxy }}
 ---
   {{- /* For Dockerfile just render it from the folder. */ -}}
   {{- if not (regexMatch "/werf.inc.yaml$" $path) }}

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -9,6 +9,7 @@ config:
       - GOLANG_VERSION
       - GOPROXY
       - SOURCE_REPO
+      - DISTRO_PACKAGES_PROXY
       - SOURCE_REPO_TAG
     allowUncommittedFiles:
       - "base_images.yml"

--- a/werf.yaml
+++ b/werf.yaml
@@ -9,6 +9,9 @@ build:
       removeLabels:
         - /.*/
 ---
+{{- $_ := set $ "DistroPackagesProxy" (env "DISTRO_PACKAGES_PROXY" "") }}
+{{- $_ := set $ "SOURCE_REPO" (env "SOURCE_REPO" "https://github.com") }}
+{{- $_ := set $ "GOPROXY" (env "GOPROXY" "https://proxy.golang.org,direct") }}
 {{ tpl (.Files.Get ".werf/base-images.yaml") $ }}
 {{ tpl (.Files.Get ".werf/consts.yaml") $ }}
 {{ tpl (.Files.Get ".werf/defines/oss-yaml.tmpl") $ }}


### PR DESCRIPTION
## Description

Align werf with the CSE external-module build checklist: set `DISTRO_PACKAGES_PROXY`, `SOURCE_REPO`, and `GOPROXY` on the root context before any `tpl` includes; pass proxy/repo fields into each image build context in `.werf/images.yaml`; allow `DISTRO_PACKAGES_PROXY` in `werf-giterminism.yaml`.

## Why do we need it, and what problem does it solve?

Same as sibling storage modules: closed-loop / proxy envs must be available at template render time and accepted by giterminism when building in restricted environments.

## What is the expected result?

`werf config render` accepts `DISTRO_PACKAGES_PROXY`; image templates receive `SOURCE_REPO`, `GOPROXY`, and `DistroPackagesProxy` on `$ctx` alongside `Root`.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
