### PR TITLE
[env] Cache GetConfig and unify BuildAll signatures

### DIFF
--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -81,7 +81,7 @@ func run(ctx context.Context, log *slog.Logger) (err error) {
 
 	envConfig, err := env.GetConfig()
 	if err != nil {
-		return u.LogError(log, fmt.Errorf("getting env config: %w", err))
+		return u.LogError(log, err)
 	}
 	log = log.With("nodeName", envConfig.NodeName())
 

--- a/images/agent/cmd/manager.go
+++ b/images/agent/cmd/manager.go
@@ -41,7 +41,6 @@ type managerConfig interface {
 	NodeName() string
 	HealthProbeBindAddress() string
 	MetricsBindAddress() string
-	IsControllerEnabled(name string) bool
 }
 
 func newManager(
@@ -94,7 +93,7 @@ func newManager(
 		return nil, u.LogError(log, fmt.Errorf("AddReadyzCheck: %w", err))
 	}
 
-	if err := controllers.BuildAll(mgr, cfg.IsControllerEnabled); err != nil {
+	if err := controllers.BuildAll(mgr); err != nil {
 		return nil, err
 	}
 

--- a/images/agent/internal/controllers/drbdm/controller.go
+++ b/images/agent/internal/controllers/drbdm/controller.go
@@ -44,7 +44,7 @@ func BuildController(mgr manager.Manager) error {
 
 	cfg, err := env.GetConfig()
 	if err != nil {
-		return fmt.Errorf("getting config: %w", err)
+		return err
 	}
 
 	cl := mgr.GetClient()

--- a/images/agent/internal/controllers/drbdr/controller.go
+++ b/images/agent/internal/controllers/drbdr/controller.go
@@ -54,7 +54,7 @@ func BuildController(mgr manager.Manager) error {
 
 	cfg, err := env.GetConfig()
 	if err != nil {
-		return fmt.Errorf("getting config: %w", err)
+		return err
 	}
 
 	cl := mgr.GetClient()

--- a/images/agent/internal/controllers/drbdrop/controller.go
+++ b/images/agent/internal/controllers/drbdrop/controller.go
@@ -38,7 +38,7 @@ const (
 func BuildController(mgr manager.Manager) error {
 	cfg, err := env.GetConfig()
 	if err != nil {
-		return fmt.Errorf("getting config: %w", err)
+		return err
 	}
 
 	cl := mgr.GetClient()

--- a/images/agent/internal/controllers/registry.go
+++ b/images/agent/internal/controllers/registry.go
@@ -24,14 +24,20 @@ import (
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/controllers/drbdm"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/controllers/drbdr"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/controllers/drbdrop"
+	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/env"
 )
 
 // BuildAll builds all controllers.
-// isEnabled is a filter function: if it returns false for a controller name,
-// that controller is skipped. When ENABLED_CONTROLLERS env is not set,
-// isEnabled returns true for all names (all controllers are started).
-func BuildAll(mgr manager.Manager, isEnabled func(string) bool) error {
+// Controllers consult env.GetConfig() (cached) for any configuration they need.
+// When ENABLED_CONTROLLERS env is not set, all controllers are started; otherwise
+// only the listed controllers are built.
+func BuildAll(mgr manager.Manager) error {
 	log := mgr.GetLogger().WithName("controller-registry")
+
+	cfg, err := env.GetConfig()
+	if err != nil {
+		return err
+	}
 
 	type builder struct {
 		name  string
@@ -44,7 +50,7 @@ func BuildAll(mgr manager.Manager, isEnabled func(string) bool) error {
 	}
 
 	for _, b := range builders {
-		if !isEnabled(b.name) {
+		if !cfg.IsControllerEnabled(b.name) {
 			log.Info("controller disabled, skipping", "controller", b.name)
 			continue
 		}

--- a/images/agent/internal/env/config.go
+++ b/images/agent/internal/env/config.go
@@ -17,11 +17,12 @@ limitations under the License.
 package env
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
+	"sync"
+
+	commonenv "github.com/deckhouse/sds-replicated-volume/lib/go/common/env"
 )
 
 const (
@@ -30,32 +31,16 @@ const (
 	DRBDMinPortEnvVar = "DRBD_MIN_PORT"
 	DRBDMaxPortEnvVar = "DRBD_MAX_PORT"
 
-	HealthProbeBindAddressEnvVar = "HEALTH_PROBE_BIND_ADDRESS"
-	MetricsPortEnvVar            = "METRICS_BIND_ADDRESS"
-	EnabledControllersEnvVar     = "ENABLED_CONTROLLERS"
-
 	// defaults are different for each app, do not merge them
 	DefaultHealthProbeBindAddress = ":4269"
 	DefaultMetricsBindAddress     = ":4270"
 )
 
-var ErrInvalidConfig = errors.New("invalid config")
-
 type config struct {
-	nodeName               string
-	drbdMinPort            uint
-	drbdMaxPort            uint
-	healthProbeBindAddress string
-	metricsBindAddress     string
-	enabledControllers     map[string]struct{} // nil means all enabled
-}
-
-func (c *config) HealthProbeBindAddress() string {
-	return c.healthProbeBindAddress
-}
-
-func (c *config) MetricsBindAddress() string {
-	return c.metricsBindAddress
+	commonenv.CommonConfig
+	nodeName    string
+	drbdMinPort uint
+	drbdMaxPort uint
 }
 
 func (c *config) DRBDMaxPort() uint {
@@ -70,17 +55,6 @@ func (c *config) NodeName() string {
 	return c.nodeName
 }
 
-// IsControllerEnabled reports whether the named controller should be started.
-// When ENABLED_CONTROLLERS is not set (or empty), all controllers are enabled.
-// When set, only the listed controllers (comma-separated) are enabled.
-func (c *config) IsControllerEnabled(name string) bool {
-	if c.enabledControllers == nil {
-		return true // not set → all enabled
-	}
-	_, ok := c.enabledControllers[name]
-	return ok
-}
-
 type Config interface {
 	NodeName() string
 	DRBDMinPort() uint
@@ -92,10 +66,23 @@ type Config interface {
 
 var _ Config = &config{}
 
+var getConfigOnce = sync.OnceValues(loadConfig)
+
+// GetConfig returns the process-wide environment configuration.
+// The first call parses environment variables; subsequent calls return the
+// cached result (and error, if any) wrapped with "getting env config".
+// The returned Config is immutable.
 func GetConfig() (Config, error) {
+	cfg, err := getConfigOnce()
+	if err != nil {
+		return nil, fmt.Errorf("getting env config: %w", err)
+	}
+	return cfg, nil
+}
+
+func loadConfig() (Config, error) {
 	cfg := &config{}
 
-	//
 	cfg.nodeName = os.Getenv(NodeNameEnvVar)
 	if cfg.nodeName == "" {
 		hostName, err := os.Hostname()
@@ -107,52 +94,29 @@ func GetConfig() (Config, error) {
 
 	minPortStr := os.Getenv(DRBDMinPortEnvVar)
 	if minPortStr == "" {
-		return cfg, fmt.Errorf("%w: %s is required", ErrInvalidConfig, DRBDMinPortEnvVar)
+		return nil, fmt.Errorf("%w: %s is required", commonenv.ErrInvalidConfig, DRBDMinPortEnvVar)
 	}
-	if minPort, err := strconv.ParseUint(minPortStr, 10, 32); err != nil {
-		return cfg, fmt.Errorf("parsing %s: %w", DRBDMinPortEnvVar, err)
-	} else {
-		cfg.drbdMinPort = uint(minPort)
+	minPort, err := strconv.ParseUint(minPortStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", DRBDMinPortEnvVar, err)
 	}
+	cfg.drbdMinPort = uint(minPort)
 
 	maxPortStr := os.Getenv(DRBDMaxPortEnvVar)
 	if maxPortStr == "" {
-		return cfg, fmt.Errorf("%w: %s is required", ErrInvalidConfig, DRBDMaxPortEnvVar)
+		return nil, fmt.Errorf("%w: %s is required", commonenv.ErrInvalidConfig, DRBDMaxPortEnvVar)
 	}
-	if maxPort, err := strconv.ParseUint(maxPortStr, 10, 32); err != nil {
-		return cfg, fmt.Errorf("parsing %s: %w", DRBDMaxPortEnvVar, err)
-	} else {
-		cfg.drbdMaxPort = uint(maxPort)
+	maxPort, err := strconv.ParseUint(maxPortStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", DRBDMaxPortEnvVar, err)
 	}
+	cfg.drbdMaxPort = uint(maxPort)
 
-	//
 	if cfg.drbdMaxPort < cfg.drbdMinPort {
-		return cfg, fmt.Errorf("%w: invalid port range %d-%d", ErrInvalidConfig, cfg.drbdMinPort, cfg.drbdMaxPort)
+		return nil, fmt.Errorf("%w: invalid port range %d-%d", commonenv.ErrInvalidConfig, cfg.drbdMinPort, cfg.drbdMaxPort)
 	}
 
-	//
-	cfg.healthProbeBindAddress = os.Getenv(HealthProbeBindAddressEnvVar)
-	if cfg.healthProbeBindAddress == "" {
-		cfg.healthProbeBindAddress = DefaultHealthProbeBindAddress
-	}
-
-	//
-	cfg.metricsBindAddress = os.Getenv(MetricsPortEnvVar)
-	if cfg.metricsBindAddress == "" {
-		cfg.metricsBindAddress = DefaultMetricsBindAddress
-	}
-
-	// Enabled controllers (optional): comma-separated list of controller names.
-	// When not set or empty, all controllers are enabled.
-	if raw := os.Getenv(EnabledControllersEnvVar); raw != "" {
-		cfg.enabledControllers = make(map[string]struct{})
-		for _, name := range strings.Split(raw, ",") {
-			name = strings.TrimSpace(name)
-			if name != "" {
-				cfg.enabledControllers[name] = struct{}{}
-			}
-		}
-	}
+	cfg.Load(DefaultHealthProbeBindAddress, DefaultMetricsBindAddress)
 
 	return cfg, nil
 }

--- a/images/controller/cmd/main.go
+++ b/images/controller/cmd/main.go
@@ -66,7 +66,7 @@ func run(ctx context.Context, log *slog.Logger) (err error) {
 
 	envConfig, err := env.GetConfig()
 	if err != nil {
-		return fmt.Errorf("getting env config: %w", err)
+		return err
 	}
 
 	// MANAGER

--- a/images/controller/cmd/manager.go
+++ b/images/controller/cmd/manager.go
@@ -41,7 +41,6 @@ type managerConfig interface {
 	SchedulerExtenderURL() string
 	HealthProbeBindAddress() string
 	MetricsBindAddress() string
-	IsControllerEnabled(name string) bool
 }
 
 func newManager(
@@ -99,7 +98,7 @@ func newManager(
 		return nil, u.LogError(log, fmt.Errorf("AddReadyzCheck: %w", err))
 	}
 
-	if err := controllers.BuildAll(mgr, envConfig.PodNamespace(), envConfig.SchedulerExtenderURL(), envConfig.IsControllerEnabled); err != nil {
+	if err := controllers.BuildAll(mgr); err != nil {
 		return nil, err
 	}
 

--- a/images/controller/internal/controllers/registry.go
+++ b/images/controller/internal/controllers/registry.go
@@ -27,18 +27,20 @@ import (
 	rvcontroller "github.com/deckhouse/sds-replicated-volume/images/controller/internal/controllers/rv_controller"
 	rvrcontroller "github.com/deckhouse/sds-replicated-volume/images/controller/internal/controllers/rvr_controller"
 	rvrschedulingcontroller "github.com/deckhouse/sds-replicated-volume/images/controller/internal/controllers/rvr_scheduling_controller"
+	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/env"
 )
 
 // BuildAll builds all controllers.
-// podNamespace is the namespace where the controller pod runs, used by controllers
-// that need to access other pods in this namespace (e.g., agent pods).
-// schedulerExtenderURL is the URL of the scheduler extender service, used by the
-// rvr-scheduling-controller to query LVG scores.
-// isEnabled is a filter function: if it returns false for a controller name,
-// that controller is skipped. When ENABLED_CONTROLLERS env is not set,
-// isEnabled returns true for all names (all controllers are started).
-func BuildAll(mgr manager.Manager, podNamespace string, schedulerExtenderURL string, isEnabled func(string) bool) error {
+// Controllers consult env.GetConfig() (cached) for any configuration they need.
+// When ENABLED_CONTROLLERS env is not set, all controllers are started; otherwise
+// only the listed controllers are built.
+func BuildAll(mgr manager.Manager) error {
 	log := mgr.GetLogger().WithName("controller-registry")
+
+	cfg, err := env.GetConfig()
+	if err != nil {
+		return err
+	}
 
 	// Must be first: controllers rely on MatchingFields against these indexes.
 	if err := RegisterIndexes(mgr); err != nil {
@@ -51,21 +53,15 @@ func BuildAll(mgr manager.Manager, podNamespace string, schedulerExtenderURL str
 	}
 	builders := []builder{
 		{name: rvcontroller.RVControllerName, build: rvcontroller.BuildController},
-		{name: rvrschedulingcontroller.RVRSchedulingControllerName, build: func(mgr manager.Manager) error {
-			return rvrschedulingcontroller.BuildController(mgr, schedulerExtenderURL)
-		}},
+		{name: rvrschedulingcontroller.RVRSchedulingControllerName, build: rvrschedulingcontroller.BuildController},
 		{name: rsccontroller.RSCControllerName, build: rsccontroller.BuildController},
 		{name: nodecontroller.NodeControllerName, build: nodecontroller.BuildController},
-		{name: rspcontroller.RSPControllerName, build: func(mgr manager.Manager) error {
-			return rspcontroller.BuildController(mgr, podNamespace)
-		}},
-		{name: rvrcontroller.RVRControllerName, build: func(mgr manager.Manager) error {
-			return rvrcontroller.BuildController(mgr, podNamespace)
-		}},
+		{name: rspcontroller.RSPControllerName, build: rspcontroller.BuildController},
+		{name: rvrcontroller.RVRControllerName, build: rvrcontroller.BuildController},
 	}
 
 	for _, b := range builders {
-		if !isEnabled(b.name) {
+		if !cfg.IsControllerEnabled(b.name) {
 			log.Info("controller disabled, skipping", "controller", b.name)
 			continue
 		}

--- a/images/controller/internal/controllers/rsp_controller/controller.go
+++ b/images/controller/internal/controllers/rsp_controller/controller.go
@@ -34,6 +34,7 @@ import (
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 	"github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/controllers/controlleroptions"
+	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/env"
 	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/indexes"
 )
 
@@ -41,7 +42,13 @@ const RSPControllerName = "rsp-controller"
 
 // BuildController registers the RSP controller with the manager.
 // It sets up watches on ReplicatedStoragePool, Node, LVMVolumeGroup, and agent Pod resources.
-func BuildController(mgr manager.Manager, agentPodNamespace string) error {
+func BuildController(mgr manager.Manager) error {
+	cfg, err := env.GetConfig()
+	if err != nil {
+		return err
+	}
+	agentPodNamespace := cfg.PodNamespace()
+
 	cl := mgr.GetClient()
 
 	rec := NewReconciler(cl, mgr.GetLogger().WithName(RSPControllerName), agentPodNamespace)

--- a/images/controller/internal/controllers/rvr_controller/controller.go
+++ b/images/controller/internal/controllers/rvr_controller/controller.go
@@ -33,13 +33,20 @@ import (
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 	"github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/controllers/controlleroptions"
+	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/env"
 	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/idset"
 	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/indexes"
 )
 
 const RVRControllerName = "rvr-controller"
 
-func BuildController(mgr manager.Manager, agentPodNamespace string) error {
+func BuildController(mgr manager.Manager) error {
+	cfg, err := env.GetConfig()
+	if err != nil {
+		return err
+	}
+	agentPodNamespace := cfg.PodNamespace()
+
 	cl := mgr.GetClient()
 	scheme := mgr.GetScheme()
 

--- a/images/controller/internal/controllers/rvr_scheduling_controller/controller.go
+++ b/images/controller/internal/controllers/rvr_scheduling_controller/controller.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/controllers/controlleroptions"
+	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/env"
 	"github.com/deckhouse/sds-replicated-volume/images/controller/internal/indexes"
 	schext "github.com/deckhouse/sds-replicated-volume/images/controller/internal/scheduler_extender"
 )
@@ -37,7 +38,13 @@ import (
 // RVRSchedulingControllerName is the controller name for rvr-scheduling-controller.
 const RVRSchedulingControllerName = "rvr-scheduling-controller"
 
-func BuildController(mgr manager.Manager, schedulerExtenderURL string) error {
+func BuildController(mgr manager.Manager) error {
+	cfg, err := env.GetConfig()
+	if err != nil {
+		return err
+	}
+	schedulerExtenderURL := cfg.SchedulerExtenderURL()
+
 	cl := mgr.GetClient()
 
 	if schedulerExtenderURL == "" {

--- a/images/controller/internal/env/config.go
+++ b/images/controller/internal/env/config.go
@@ -17,40 +17,26 @@ limitations under the License.
 package env
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"strings"
+	"sync"
+
+	commonenv "github.com/deckhouse/sds-replicated-volume/lib/go/common/env"
 )
 
 const (
-	PodNamespaceEnvVar           = "POD_NAMESPACE"
-	SchedulerExtenderURLEnvVar   = "SCHEDULER_EXTENDER_URL"
-	HealthProbeBindAddressEnvVar = "HEALTH_PROBE_BIND_ADDRESS"
-	MetricsPortEnvVar            = "METRICS_BIND_ADDRESS"
-	EnabledControllersEnvVar     = "ENABLED_CONTROLLERS"
+	PodNamespaceEnvVar         = "POD_NAMESPACE"
+	SchedulerExtenderURLEnvVar = "SCHEDULER_EXTENDER_URL"
 
 	// defaults are different for each app, do not merge them
 	DefaultHealthProbeBindAddress = ":4271"
 	DefaultMetricsBindAddress     = ":4272"
 )
 
-var ErrInvalidConfig = errors.New("invalid config")
-
 type Config struct {
-	podNamespace           string
-	schedulerExtenderURL   string
-	healthProbeBindAddress string
-	metricsBindAddress     string
-	enabledControllers     map[string]struct{} // nil means all enabled
-}
-
-func (c *Config) HealthProbeBindAddress() string {
-	return c.healthProbeBindAddress
-}
-
-func (c *Config) MetricsBindAddress() string {
-	return c.metricsBindAddress
+	commonenv.CommonConfig
+	podNamespace         string
+	schedulerExtenderURL string
 }
 
 func (c *Config) PodNamespace() string {
@@ -59,17 +45,6 @@ func (c *Config) PodNamespace() string {
 
 func (c *Config) SchedulerExtenderURL() string {
 	return c.schedulerExtenderURL
-}
-
-// IsControllerEnabled reports whether the named controller should be started.
-// When ENABLED_CONTROLLERS is not set (or empty), all controllers are enabled.
-// When set, only the listed controllers (comma-separated) are enabled.
-func (c *Config) IsControllerEnabled(name string) bool {
-	if c.enabledControllers == nil {
-		return true // not set → all enabled
-	}
-	_, ok := c.enabledControllers[name]
-	return ok
 }
 
 type ConfigProvider interface {
@@ -82,44 +57,36 @@ type ConfigProvider interface {
 
 var _ ConfigProvider = &Config{}
 
+var getConfigOnce = sync.OnceValues(loadConfig)
+
+// GetConfig returns the process-wide environment configuration.
+// The first call parses environment variables; subsequent calls return the
+// cached result (and error, if any) wrapped with "getting env config".
+// The returned *Config is immutable.
 func GetConfig() (*Config, error) {
+	cfg, err := getConfigOnce()
+	if err != nil {
+		return nil, fmt.Errorf("getting env config: %w", err)
+	}
+	return cfg, nil
+}
+
+func loadConfig() (*Config, error) {
 	cfg := &Config{}
 
 	// Pod namespace (required): used to discover agent pods.
 	cfg.podNamespace = os.Getenv(PodNamespaceEnvVar)
 	if cfg.podNamespace == "" {
-		return nil, fmt.Errorf("%w: %s is required", ErrInvalidConfig, PodNamespaceEnvVar)
+		return nil, fmt.Errorf("%w: %s is required", commonenv.ErrInvalidConfig, PodNamespaceEnvVar)
 	}
 
 	// Scheduler extender URL (required): used to query LVG scores from the scheduler extender.
 	cfg.schedulerExtenderURL = os.Getenv(SchedulerExtenderURLEnvVar)
 	if cfg.schedulerExtenderURL == "" {
-		return nil, fmt.Errorf("%w: %s is required", ErrInvalidConfig, SchedulerExtenderURLEnvVar)
+		return nil, fmt.Errorf("%w: %s is required", commonenv.ErrInvalidConfig, SchedulerExtenderURLEnvVar)
 	}
 
-	// Health probe bind address (optional, has default).
-	cfg.healthProbeBindAddress = os.Getenv(HealthProbeBindAddressEnvVar)
-	if cfg.healthProbeBindAddress == "" {
-		cfg.healthProbeBindAddress = DefaultHealthProbeBindAddress
-	}
-
-	// Metrics bind address (optional, has default).
-	cfg.metricsBindAddress = os.Getenv(MetricsPortEnvVar)
-	if cfg.metricsBindAddress == "" {
-		cfg.metricsBindAddress = DefaultMetricsBindAddress
-	}
-
-	// Enabled controllers (optional): comma-separated list of controller names.
-	// When not set or empty, all controllers are enabled.
-	if raw := os.Getenv(EnabledControllersEnvVar); raw != "" {
-		cfg.enabledControllers = make(map[string]struct{})
-		for _, name := range strings.Split(raw, ",") {
-			name = strings.TrimSpace(name)
-			if name != "" {
-				cfg.enabledControllers[name] = struct{}{}
-			}
-		}
-	}
+	cfg.Load(DefaultHealthProbeBindAddress, DefaultMetricsBindAddress)
 
 	return cfg, nil
 }

--- a/lib/go/common/env/env.go
+++ b/lib/go/common/env/env.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package env provides shared environment configuration parsing for
+// sds-replicated-volume binaries.
+//
+// Concrete app-specific config types embed CommonConfig and call its Load
+// method to populate the shared fields, supplying their own defaults for the
+// bind addresses.
+package env
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+const (
+	HealthProbeBindAddressEnvVar = "HEALTH_PROBE_BIND_ADDRESS"
+	MetricsBindAddressEnvVar     = "METRICS_BIND_ADDRESS"
+	EnabledControllersEnvVar     = "ENABLED_CONTROLLERS"
+)
+
+// ErrInvalidConfig is returned (wrapped) when the loaded environment is
+// invalid. Callers may use errors.Is to detect it.
+var ErrInvalidConfig = errors.New("invalid config")
+
+// CommonConfig holds env vars common to all sds-replicated-volume binaries.
+// Concrete app configs embed CommonConfig and call Load to populate it.
+type CommonConfig struct {
+	healthProbeBindAddress string
+	metricsBindAddress     string
+	enabledControllers     map[string]struct{} // nil means all enabled
+}
+
+func (c *CommonConfig) HealthProbeBindAddress() string {
+	return c.healthProbeBindAddress
+}
+
+func (c *CommonConfig) MetricsBindAddress() string {
+	return c.metricsBindAddress
+}
+
+// IsControllerEnabled reports whether the named controller should be started.
+// When ENABLED_CONTROLLERS is not set (or empty), all controllers are enabled.
+// When set, only the listed controllers (comma-separated) are enabled.
+func (c *CommonConfig) IsControllerEnabled(name string) bool {
+	if c.enabledControllers == nil {
+		return true
+	}
+	_, ok := c.enabledControllers[name]
+	return ok
+}
+
+// Load populates the common fields from environment variables, falling back
+// to the supplied defaults for the bind addresses when not set. This method
+// has no failure modes and never returns an error.
+func (c *CommonConfig) Load(defaultHealthProbeBindAddress, defaultMetricsBindAddress string) {
+	c.healthProbeBindAddress = os.Getenv(HealthProbeBindAddressEnvVar)
+	if c.healthProbeBindAddress == "" {
+		c.healthProbeBindAddress = defaultHealthProbeBindAddress
+	}
+
+	c.metricsBindAddress = os.Getenv(MetricsBindAddressEnvVar)
+	if c.metricsBindAddress == "" {
+		c.metricsBindAddress = defaultMetricsBindAddress
+	}
+
+	if raw := os.Getenv(EnabledControllersEnvVar); raw != "" {
+		c.enabledControllers = make(map[string]struct{})
+		for name := range strings.SplitSeq(raw, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				c.enabledControllers[name] = struct{}{}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

Style-only, non-breaking refactor that unifies the agent and controller registries and consolidates shared environment configuration:

- New `lib/go/common/env` package with `CommonConfig` (health-probe / metrics bind address, `ENABLED_CONTROLLERS` parsing). Both `images/controller/internal/env` and `images/agent/internal/env` embed it.
- `env.GetConfig()` is memoized via `sync.OnceValues` and wraps the cached error with `"getting env config: %w"` once, so call sites no longer re-wrap.
- Both registries now expose exactly `func BuildAll(mgr manager.Manager) error`. Per-controller `BuildController(...)` functions drop their config parameters (`agentPodNamespace`, `schedulerExtenderURL`) and read them from the cached `env.GetConfig()` themselves.

## Why do we need it, and what problem does it solve?

The two registry entrypoints had drifted: different signatures and different sets of plumbed-through arguments. The agent already fetched its config from `env.GetConfig()` inside each `BuildController`, while the controller side threaded values through `BuildAll`. Both env packages also duplicated the parsing of the shared `HEALTH_PROBE_BIND_ADDRESS`, `METRICS_BIND_ADDRESS`, and `ENABLED_CONTROLLERS` variables. Unifying the signatures and moving the duplicate parsing into `lib/go/common/env` keeps the two binaries' wiring consistent and makes future common-env additions a one-place change.

## What is the expected result?

No functional changes. Both binaries read the same env vars and apply the same defaults as before.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.