### PR TITLE
[agent] Fix agent predicates to ignore status updates

### DIFF
--- a/images/agent/internal/controllers/drbdr/predicates.go
+++ b/images/agent/internal/controllers/drbdr/predicates.go
@@ -26,20 +26,22 @@ import (
 
 // drbdrPredicates returns predicates for DRBDResource filtering.
 // Only resources belonging to the specified node will trigger reconciliation.
+// Updates to non-spec fields are ignored too.
 func drbdrPredicates(nodeName string) []predicate.Predicate {
 	return []predicate.Predicate{
 		predicate.Funcs{
 			CreateFunc: func(e event.TypedCreateEvent[client.Object]) bool {
-				dr, ok := e.Object.(*v1alpha1.DRBDResource)
-				return ok && dr.Spec.NodeName == nodeName
+				dr := e.Object.(*v1alpha1.DRBDResource)
+				return dr.Spec.NodeName == nodeName
 			},
 			UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
-				dr, ok := e.ObjectNew.(*v1alpha1.DRBDResource)
-				return ok && dr.Spec.NodeName == nodeName
+				drNew := e.ObjectNew.(*v1alpha1.DRBDResource)
+				drOld := e.ObjectOld.(*v1alpha1.DRBDResource)
+				return drNew.Spec.NodeName == nodeName && drNew.Generation != drOld.Generation
 			},
 			DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
-				dr, ok := e.Object.(*v1alpha1.DRBDResource)
-				return ok && dr.Spec.NodeName == nodeName
+				dr := e.Object.(*v1alpha1.DRBDResource)
+				return dr.Spec.NodeName == nodeName
 			},
 			GenericFunc: func(_ event.TypedGenericEvent[client.Object]) bool {
 				return false


### PR DESCRIPTION
## Description

Refines `drbdrPredicates` in the agent's DRBDResource controller so that update events are filtered down to spec changes only. The `UpdateFunc` now compares `ObjectNew.Generation` and `ObjectOld.Generation` in addition to the existing node-name check, so status-only updates (which don't bump `Generation`) no longer trigger reconciliation.

The redundant `ok` checks on type assertions were also dropped, since the controller is already wired with `For(&v1alpha1.DRBDResource{})` and the cast cannot fail.

No critical cluster components are affected.

## Why do we need it, and what problem does it solve?

The agent reconciler writes back to `DRBDResource.Status` as part of its work. With the previous predicates, every status patch the agent itself produced bounced back as an update event and re-triggered reconciliation, causing a tight self-feedback loop and unnecessary load. Filtering on `Generation` is the standard way to ignore status-only changes and keeps the controller reacting only to user/spec-driven changes.

## What is the expected result?

- After applying, the agent's DRBDResource controller MUST NOT reconcile on status-only updates to `DRBDResource` objects belonging to its node.
- It MUST still reconcile on:
  - create/delete events for resources whose `spec.nodeName` matches the node, and
  - update events where `spec` (or any other generation-bumping field) actually changed.
- It MUST continue to ignore objects whose `spec.nodeName` does not match the node.
- No CRD or API changes; no user-visible behavior change beyond reduced reconcile churn.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.