### PR TITLE
[agent,kmsg] Forward DRBD kernel messages to agent logs

### DIFF
--- a/images/agent/internal/controllers/drbdkmsg/controller.go
+++ b/images/agent/internal/controllers/drbdkmsg/controller.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package drbdkmsg surfaces DRBD-related kernel messages from /dev/kmsg
+// in the agent pod's stdout/stderr, so on-call SREs can diagnose
+// split-brain, IO error, and sync-failure events from kubectl logs
+// instead of having to SSH into each node and read dmesg.
+package drbdkmsg
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// ControllerName is the stable name used by the controller registry to
+// gate this runnable on the ENABLED_CONTROLLERS env var.
+const ControllerName = "drbdkmsg-controller"
+
+// BuildController constructs the DRBD-kmsg forwarder runnable and adds
+// it to the manager. It performs no I/O at build time; the kernel log
+// is opened lazily inside Start so a missing or inaccessible /dev/kmsg
+// does not abort agent startup.
+func BuildController(mgr manager.Manager) error {
+	fwd := NewForwarder()
+	if err := mgr.Add(fwd); err != nil {
+		return fmt.Errorf("adding drbdkmsg forwarder runnable: %w", err)
+	}
+	return nil
+}

--- a/images/agent/internal/controllers/drbdkmsg/forwarder.go
+++ b/images/agent/internal/controllers/drbdkmsg/forwarder.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbdkmsg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/deckhouse/sds-replicated-volume/lib/go/common/kmsg"
+)
+
+// Look for messages starting with "drbd"
+var drbdMatch = []byte(";drbd")
+
+var (
+	retryBaseDelay = 10 * time.Millisecond
+	retryMaxDelay  = 10 * time.Second
+)
+
+// Kernel printk severities (kernel.h / RFC 5424). The bottom 3 bits of
+// the wire-format <pri> field carry the severity; the upper bits are
+// the facility, which we ignore.
+const (
+	kernSeverityWarning = 4
+	kernSeverityDebug   = 7
+)
+
+// Forwarder is a manager.Runnable that follows /dev/kmsg and emits
+// DRBD-tagged kernel messages through the controller-runtime logger.
+type Forwarder struct {
+	// retryDelay is the current backoff between failed kmsg.Open
+	// attempts and follow restarts. It doubles up to retryMaxDelay
+	// after each failure and is reset to retryBaseDelay every time
+	// follow successfully reads a record.
+	retryDelay time.Duration
+}
+
+func NewForwarder() *Forwarder {
+	return &Forwarder{}
+}
+
+// Start runs the kmsg follow loop until ctx is canceled. It never
+// returns a non-nil error: kmsg forwarding is observability, not a
+// critical path, so any failure here is logged and retried instead of
+// crashing the agent.
+func (f *Forwarder) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName(ControllerName)
+	logger.Info("starting DRBD kmsg forwarder")
+
+	buf := make([]byte, kmsg.MaxRecordSize)
+	f.retryDelay = retryBaseDelay
+	for ctx.Err() == nil {
+		err := f.follow(ctx, logger, buf)
+		if ctx.Err() != nil {
+			return nil
+		}
+		logger.Error(err, "kmsg follow error; retrying", "retryDelay", f.retryDelay)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(f.retryDelay):
+		}
+		f.retryDelay = min(f.retryDelay*2, retryMaxDelay)
+	}
+	return nil
+}
+
+// NeedLeaderElection is false: /dev/kmsg is per-node, so every agent
+// instance follows its own.
+func (*Forwarder) NeedLeaderElection() bool {
+	return false
+}
+
+// follow opens /dev/kmsg and reads records into buf until the watchdog
+// closes the reader (ctx cancel) or an unrecoverable read error
+// occurs. The watchdog goroutine is the sole closer of r: closing
+// from anywhere else would race with a Read parked on the poller.
+//
+// Each successful Read resets f.retryDelay so a healthy stream of
+// records collapses any prior backoff back to retryBaseDelay.
+func (f *Forwarder) follow(ctx context.Context, logger logr.Logger, buf []byte) error {
+	r, err := kmsg.Open()
+	if err != nil {
+		return err
+	}
+
+	// Wrap ctx so the watchdog wakes when follow returns for any
+	// reason, not just on outer cancellation.
+	ctx, cancel := context.WithCancel(ctx)
+	watchdogDone := make(chan struct{})
+	go func() {
+		defer close(watchdogDone)
+		<-ctx.Done()
+		_ = r.Close()
+	}()
+	defer func() {
+		cancel()
+		<-watchdogDone
+	}()
+
+	for {
+		n, err := r.Read(buf)
+		if err != nil {
+			if errors.Is(err, os.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		f.retryDelay = retryBaseDelay
+		line := buf[:n]
+		if !bytes.Contains(line, drbdMatch) {
+			continue
+		}
+		sev := parseSeverity(line)
+		line = bytes.TrimSpace(line)
+
+		const event = "DRBD kernel message"
+		switch {
+		case sev >= 0 && sev <= kernSeverityWarning:
+			// EMERG..WARNING: real problems and "something might be
+			// wrong" (e.g. DRBD resync rate caps, bitmap pressure).
+			// Surface as Error so SREs notice in kubectl logs.
+			logger.Error(nil, event, "text", string(line))
+		case sev == kernSeverityDebug:
+			logger.V(1).Info(event, "text", string(line))
+		default:
+			// NOTICE, INFO, or unparseable header: routine.
+			logger.Info(event, "text", string(line))
+		}
+	}
+}
+
+// parseSeverity extracts the syslog severity (0..7) from the leading
+// <pri> field of a /dev/kmsg wire-format record without allocating.
+// The format is "<pri>,<seq>,<ts>,<flags>;<message>"; <pri> is at most
+// 3 ASCII digits and encodes facility<<3 | severity, so the severity
+// is the low 3 bits. Returns -1 if the header is missing or malformed.
+func parseSeverity(line []byte) int {
+	var pri int
+	for i := range line {
+		b := line[i]
+		if b == ',' {
+			if i == 0 || i > 3 {
+				return -1
+			}
+			return pri & 7
+		}
+		if b < '0' || b > '9' {
+			return -1
+		}
+		pri = pri*10 + int(b-'0')
+	}
+	return -1
+}

--- a/images/agent/internal/controllers/registry.go
+++ b/images/agent/internal/controllers/registry.go
@@ -21,6 +21,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/controllers/drbdkmsg"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/controllers/drbdm"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/controllers/drbdr"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/controllers/drbdrop"
@@ -47,6 +48,7 @@ func BuildAll(mgr manager.Manager) error {
 		{name: drbdm.ControllerName, build: drbdm.BuildController},
 		{name: drbdr.ControllerName, build: drbdr.BuildController},
 		{name: drbdrop.ControllerName, build: drbdrop.BuildController},
+		{name: drbdkmsg.ControllerName, build: drbdkmsg.BuildController},
 	}
 
 	for _, b := range builders {

--- a/lib/go/common/kmsg/kmsg.go
+++ b/lib/go/common/kmsg/kmsg.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kmsg exposes the Linux structured kernel log (/dev/kmsg) as
+// an io.ReadCloser that delivers one record per Read.
+package kmsg
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+var KmsgPath = "/dev/kmsg"
+
+// MaxRecordSize is CONSOLE_EXT_LOG_MAX from kernel/printk/printk.c —
+// the kernel never emits a single /dev/kmsg record longer than this.
+// Pass a buffer at least this large to Reader.Read so the kernel
+// never returns EINVAL for an oversized record.
+const MaxRecordSize = 8 * 1024
+
+// Reader streams /dev/kmsg records via io.Reader. Each successful Read
+// returns the bytes of one record verbatim, including the wire-format
+// header (<pri>,<seq>,<ts>,<flags>;) and the trailing record-terminator
+// newline.
+//
+// Read does not recover from kernel errors: EPIPE (ring-buffer
+// overflow), EINVAL (oversized record), and any other Read failure
+// are returned to the caller as-is. The next Read after such an error
+// reseeks to /dev/kmsg's current tail before issuing the underlying
+// read; records produced during the error window are unrecoverable.
+//
+// On the poller-backed fd, Read blocks until a record arrives or the
+// underlying file is closed (returning os.ErrClosed). Callers that
+// want to unblock Read on context cancel must arrange a goroutine
+// that calls Close — closing from anywhere else races with the
+// parked Read.
+type Reader struct {
+	kmsg    io.ReadSeekCloser
+	reading bool
+}
+
+// Open opens /dev/kmsg in non-blocking, close-on-exec mode. The
+// initial seek to the log's tail is deferred to the first Read.
+//
+// O_NONBLOCK matters: os.NewFile inspects the fd and, if it is
+// non-blocking, registers it with the runtime poller (see kindNonBlock
+// in src/os/file_unix.go). Without it the read would park an OS thread
+// in a blocking syscall instead of just a goroutine on epoll_wait.
+//
+// O_CLOEXEC keeps the fd out of any child processes spawned later.
+func Open() (*Reader, error) {
+	fd, err := syscall.Open(KmsgPath, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", KmsgPath, err)
+	}
+	return &Reader{kmsg: os.NewFile(uintptr(fd), KmsgPath)}, nil
+}
+
+func (r *Reader) Read(p []byte) (int, error) {
+	if !r.reading {
+		if _, err := r.kmsg.Seek(0, io.SeekEnd); err != nil {
+			return 0, fmt.Errorf("seeking to end of %s: %w", KmsgPath, err)
+		}
+		r.reading = true
+	}
+	n, err := r.kmsg.Read(p)
+	if err != nil {
+		r.reading = false
+		err = fmt.Errorf("reading %s: %w", KmsgPath, err)
+	}
+	return n, err
+}
+
+func (r *Reader) Close() error {
+	return r.kmsg.Close()
+}

--- a/lib/go/common/kmsg/kmsg_test.go
+++ b/lib/go/common/kmsg/kmsg_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmsg
+
+import (
+	"errors"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// recordReader returns one canned record per Read. errAt injects a
+// one-shot error at that record index; -1 disables.
+type recordReader struct {
+	records   [][]byte
+	idx       int
+	errAt     int
+	err       error
+	seekCalls int
+	seekErr   error
+}
+
+func (r *recordReader) Read(p []byte) (int, error) {
+	if r.idx == r.errAt {
+		r.errAt = -1
+		return 0, r.err
+	}
+	if r.idx >= len(r.records) {
+		// Mirrors what a real fd does after Close, so tests reuse
+		// the production stop path instead of needing a test-only
+		// io.EOF branch.
+		return 0, os.ErrClosed
+	}
+	n := copy(p, r.records[r.idx])
+	r.idx++
+	return n, nil
+}
+
+func (r *recordReader) Seek(offset int64, _ int) (int64, error) {
+	r.seekCalls++
+	return offset, r.seekErr
+}
+
+func (*recordReader) Close() error { return nil }
+
+// readAll collects records via Reader.Read until it returns
+// os.ErrClosed; any other error fails the test.
+func readAll(t *testing.T, r *Reader) []string {
+	t.Helper()
+	var got []string
+	buf := make([]byte, MaxRecordSize)
+	for {
+		n, err := r.Read(buf)
+		if err != nil {
+			if !errors.Is(err, os.ErrClosed) {
+				t.Fatalf("Read error: %v", err)
+			}
+			return got
+		}
+		got = append(got, string(buf[:n]))
+	}
+}
+
+func TestReaderHappyPath(t *testing.T) {
+	t.Parallel()
+	src := &recordReader{
+		records: [][]byte{
+			[]byte("6,1,1000,-;first\n"),
+			[]byte("5,2,2000,-;second\n"),
+			[]byte("4,3,3000,-;third\n"),
+		},
+		errAt: -1,
+	}
+	got := readAll(t, &Reader{kmsg: src})
+	want := []string{"6,1,1000,-;first\n", "5,2,2000,-;second\n", "4,3,3000,-;third\n"}
+	if len(got) != len(want) {
+		t.Fatalf("want %d records, got %d (%v)", len(want), len(got), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+	if src.seekCalls != 1 {
+		t.Errorf("seekCalls: got %d, want 1 (single seek-to-tail on first Read)", src.seekCalls)
+	}
+}
+
+func TestReaderResumesAfterError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("transient")
+	src := &recordReader{
+		records: [][]byte{
+			[]byte("6,1,1000,-;before\n"),
+			[]byte("6,2,2000,-;after\n"),
+		},
+		errAt: 1,
+		err:   wantErr,
+	}
+	r := &Reader{kmsg: src}
+	buf := make([]byte, MaxRecordSize)
+
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("Read 1 error: %v", err)
+	}
+	if got := string(buf[:n]); got != "6,1,1000,-;before\n" {
+		t.Errorf("Read 1 = %q, want %q", got, "6,1,1000,-;before\n")
+	}
+	if src.seekCalls != 1 {
+		t.Errorf("after Read 1: seekCalls = %d, want 1", src.seekCalls)
+	}
+
+	if _, err := r.Read(buf); !errors.Is(err, wantErr) {
+		t.Fatalf("Read 2: got err=%v, want %v", err, wantErr)
+	}
+	if src.seekCalls != 1 {
+		t.Errorf("after Read 2 (error): seekCalls = %d, want still 1", src.seekCalls)
+	}
+
+	n, err = r.Read(buf)
+	if err != nil {
+		t.Fatalf("Read 3 error: %v", err)
+	}
+	if got := string(buf[:n]); got != "6,2,2000,-;after\n" {
+		t.Errorf("Read 3 = %q, want %q", got, "6,2,2000,-;after\n")
+	}
+	if src.seekCalls != 2 {
+		t.Errorf("after Read 3 (post-error reseek): seekCalls = %d, want 2", src.seekCalls)
+	}
+}
+
+func TestReaderReseekErrorPropagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("seek broken")
+	src := &recordReader{
+		records: [][]byte{[]byte("6,1,1000,-;hi\n")},
+		errAt:   -1,
+		seekErr: wantErr,
+	}
+	buf := make([]byte, MaxRecordSize)
+	_, err := (&Reader{kmsg: src}).Read(buf)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got err=%v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestReaderUnblocksOnClose(t *testing.T) {
+	t.Parallel()
+	r := &Reader{kmsg: newBlockingReader()}
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, MaxRecordSize)
+		_, err := r.Read(buf)
+		done <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	_ = r.Close()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("Read returned err=%v, want os.ErrClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not return after Close")
+	}
+}
+
+// blockingReader parks Read until Close is invoked, mimicking the real
+// /dev/kmsg behavior under the poller: a Read on an empty buffer waits,
+// and closing the fd unparks it with os.ErrClosed.
+type blockingReader struct {
+	ch     chan struct{}
+	closed atomic.Bool
+}
+
+func newBlockingReader() *blockingReader {
+	return &blockingReader{ch: make(chan struct{})}
+}
+
+func (b *blockingReader) Read(_ []byte) (int, error) {
+	<-b.ch
+	return 0, os.ErrClosed
+}
+
+func (*blockingReader) Seek(int64, int) (int64, error) { return 0, nil }
+
+func (b *blockingReader) Close() error {
+	if b.closed.CompareAndSwap(false, true) {
+		close(b.ch)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Add a per-node `drbdkmsg-controller` runnable to the agent that tails `/dev/kmsg` and forwards DRBD-tagged kernel messages through the controller-runtime logger (so they appear in `kubectl logs` for the agent pod).

Built on a new `lib/go/common/kmsg` package: a thin `io.ReadCloser` over `/dev/kmsg` that delivers one record per `Read`, lazily seeks to tail, and surfaces kernel errors verbatim.

Severity mapping (kernel printk → logr):
- `EMERG..WARNING` → `Error` (shows up as `ERROR` in `kubectl logs`)
- `NOTICE`, `INFO` → `Info`
- `DEBUG` → `V(1).Info` (hidden unless `-v=1`)

Healthy reads reset the open/follow backoff (`10ms..10s`) so transient hiccups don't permanently inflate the retry delay.

## Why do we need it, and what problem does it solve?

Today, diagnosing DRBD events (split-brain, I/O errors, sync failures, bitmap pressure, etc.) requires SSHing into each node and reading `dmesg`. Operators don't always have SSH access, and even when they do, correlating events across many nodes is tedious.

With this change, DRBD kernel messages stream into the agent pod's standard log output, so the same `kubectl logs` workflow used for everything else also covers the kernel-side view of DRBD. Per-node logs naturally line up with the per-node agent.

## What is the expected result?

After rollout, on any node where the agent runs:

- `kubectl logs -n <ns> <agent-pod>` shows entries with logger name `drbdkmsg-controller` and message `"DRBD kernel message"`. The raw kmsg line (header + body, whitespace-trimmed) is on the `"text"` key.
- DRBD events with kernel severity `WARNING` or higher show up at `ERROR` level; routine `NOTICE`/`INFO` at `INFO`; `DEBUG` is hidden unless agent verbosity is raised to `-v=1`.
- Each agent forwards only its own node's `/dev/kmsg`; no leader election, no cross-node duplication.

Operational knobs:
- **Disable on a node**: exclude `drbdkmsg-controller` from the agent's `ENABLED_CONTROLLERS` env.
- **See `KERN_DEBUG` too**: raise agent log verbosity to `-v=1`.
- **Failure mode**: kmsg open/read errors are logged at `ERROR` and retried with exponential backoff (`10ms..10s`); the agent never crashes from a kmsg failure. Records emitted during a recovery window (EPIPE ring-buffer overflow, EINVAL oversized record) are lost by design.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.