### PR TITLE
fix(build): use GOPROXY secret for go mod download in all images

### DIFF
--- a/images/controller/werf.inc.yaml
+++ b/images/controller/werf.inc.yaml
@@ -34,9 +34,14 @@ mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   setup:
     - cd /src/images/{{ $.ImageName }}/cmd
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /{{ $.ImageName }}
     - chmod +x /{{ $.ImageName }}
 

--- a/images/go-hooks/werf.inc.yaml
+++ b/images/go-hooks/werf.inc.yaml
@@ -25,10 +25,14 @@ mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
 
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   install:
     - cd /usr/src/app/hooks/go
-    - go mod download
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
   beforeSetup:
     - |
       cd /usr/src/app/hooks/go;

--- a/images/linstor-affinity-controller/werf.inc.yaml
+++ b/images/linstor-affinity-controller/werf.inc.yaml
@@ -20,12 +20,18 @@ git:
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   setup:    
     - apk add --no-cache git
     - cd /usr/local/go/{{ $.ImageName }}
     - git apply /patches/*.patch
     - cd /usr/local/go/{{ $.ImageName }}/cmd/linstor-affinity-controller
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/piraeusdatastore/linstor-affinity-controller/pkg/consts.Version=v{{ include "get_oss_version_by_id" (list "LINSTOR_AFFINITY_CONTROLLER" $.Root) }}"
     - mv {{ $.ImageName }} /
     - chmod +x /{{ $.ImageName }}

--- a/images/linstor-csi/werf.inc.yaml
+++ b/images/linstor-csi/werf.inc.yaml
@@ -18,12 +18,18 @@ git:
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   setup:
     - apk add --no-cache git
     - cd /usr/local/go/linstor-csi
     - git apply /patches/*.patch
     - cd cmd/linstor-csi
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/piraeusdatastore/linstor-csi/pkg/driver.Version=v{{ include "get_oss_version_by_id" (list "LINSTOR_CSI" $.Root) }}"
     - mv linstor-csi /
     - chmod +x /linstor-csi

--- a/images/linstor-drbd-wait/werf.inc.yaml
+++ b/images/linstor-drbd-wait/werf.inc.yaml
@@ -34,9 +34,14 @@ mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   setup:
     - cd /src/images/{{ $.ImageName }}/cmd
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /{{ $.ImageName }}
     - chmod +x /{{ $.ImageName }}
 

--- a/images/linstor-scheduler-extender/werf.inc.yaml
+++ b/images/linstor-scheduler-extender/werf.inc.yaml
@@ -33,6 +33,11 @@ git:
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   beforeSetup:
     - apk add --no-cache git
@@ -44,7 +49,7 @@ shell:
     - cd /usr/local/go/{{ $.ImageName }}
     - git apply /patches/*.patch
     - go mod edit -replace=github.com/libopenstorage/stork=/usr/local/go/stork
-    - go mod tidy
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod tidy
     - cd cmd/linstor-scheduler-extender
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/piraeusdatastore/linstor-scheduler-extender/pkg/consts.Version=v{{ include "get_oss_version_by_id" (list "LINSTOR_SCHEDULER_EXTENDER" $.Root) }}"
     - mv {{ $.ImageName }} /

--- a/images/linstor-wait-until/werf.inc.yaml
+++ b/images/linstor-wait-until/werf.inc.yaml
@@ -23,11 +23,17 @@ git:
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   setup:
     - apk add --no-cache git
     - cd /usr/local/go/{{ $.ImageName }}
     - git apply /patches/*.patch
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w"
     - mv {{ $.ImageName }} /
     - chmod +x /{{ $.ImageName }}

--- a/images/spaas/werf.inc.yaml
+++ b/images/spaas/werf.inc.yaml
@@ -13,9 +13,15 @@ git:
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   setup:
     - cd /usr/local/go/{{ $.ImageName }}
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /{{ $.ImageName }}
     - chmod +x /{{ $.ImageName }}
 ---

--- a/images/webhooks/werf.inc.yaml
+++ b/images/webhooks/werf.inc.yaml
@@ -34,9 +34,14 @@ mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+
 shell:
   setup:
     - cd /src/images/{{ $.ImageName }}/cmd
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /{{ $.ImageName }}
     - chmod +x /{{ $.ImageName }}
 


### PR DESCRIPTION
## Description

Unify Go build pipelines across all images in the module: add the `GOPROXY` secret block and prefix `go mod download` / `go mod tidy` with `GOPROXY=$(cat /run/secrets/GOPROXY)` so that Go module downloads go through our configured proxy instead of the default `proxy.golang.org`.

Files changed (9):
- `images/controller/werf.inc.yaml`
- `images/webhooks/werf.inc.yaml`
- `images/go-hooks/werf.inc.yaml`
- `images/linstor-affinity-controller/werf.inc.yaml`
- `images/linstor-csi/werf.inc.yaml`
- `images/linstor-drbd-wait/werf.inc.yaml`
- `images/linstor-scheduler-extender/werf.inc.yaml`
- `images/linstor-wait-until/werf.inc.yaml`
- `images/spaas/werf.inc.yaml`

In each file:
1. Added the `secrets: - id: GOPROXY` block (sourcing from the `GOPROXY` variable already exported in `werf.yaml`).
2. Added `GOPROXY=$(cat /run/secrets/GOPROXY) go mod download` before `go build` where it was missing (in `linstor-scheduler-extender` the prefix is added to the existing `go mod tidy`, since that is what actually fetches modules there).

## Why do we need it, and what problem does it solve?

This module was the only one in the storage family that did not pipe Go module downloads through the corporate `GOPROXY`. The variable was already declared in `werf.yaml` (`GOPROXY = env "GOPROXY" "https://proxy.golang.org,direct"`) but never actually consumed. As a result builds either fail in environments without access to `proxy.golang.org`, or silently fetch dependencies bypassing the configured proxy.

After this change the build pattern matches the other storage modules (csi-ceph, csi-nfs, csi-s3, sds-local-volume, sds-node-configurator, snapshot-controller, state-snapshotter, storage-foundation, storage-volume-data-manager, ...).

## What is the expected result?

- All image builds in this module succeed in environments that only have access to the configured `GOPROXY`.
- All Go dependencies (including those pulled by `go mod tidy` in `linstor-scheduler-extender`) are fetched through the same proxy as the rest of the storage modules.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.