### PR TITLE
Propagate StorageClass labels from ReplicatedStorageClass CR

### DIFF
--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -14,6 +14,11 @@
 ---
 image: images-digests
 fromImage: builder/alpine
+import:
+  - image: tools/jq
+    add: /usr/bin/jq
+    to: /usr/bin/jq
+    before: setup
 dependencies:
 {{- range $ImageID := $ImagesIDList }}
   {{- $ImageNameCamel  := $ImageID | splitList "/" | last  | camelcase | untitle }}
@@ -24,8 +29,6 @@ dependencies:
       targetEnv: MODULE_IMAGE_DIGEST_{{ $ImageNameCamel }}
 {{- end }}
 shell:
-  beforeInstall:
-  - apk add --no-cache jq
   setup:
     - |
       env | grep MODULE_IMAGE_DIGEST | jq -Rn '

--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -14,11 +14,6 @@
 ---
 image: images-digests
 fromImage: builder/alpine
-import:
-  - image: tools/jq
-    add: /usr/bin/jq
-    to: /usr/bin/jq
-    before: setup
 dependencies:
 {{- range $ImageID := $ImagesIDList }}
   {{- $ImageNameCamel  := $ImageID | splitList "/" | last  | camelcase | untitle }}
@@ -29,6 +24,8 @@ dependencies:
       targetEnv: MODULE_IMAGE_DIGEST_{{ $ImageNameCamel }}
 {{- end }}
 shell:
+  beforeInstall:
+  - apk add --no-cache jq
   setup:
     - |
       env | grep MODULE_IMAGE_DIGEST | jq -Rn '

--- a/images/controller/pkg/controller/replicated_storage_class.go
+++ b/images/controller/pkg/controller/replicated_storage_class.go
@@ -153,7 +153,10 @@ func NewReplicatedStorageClass(
 			log.Debug(fmt.Sprintf("[ReplicatedStorageClassReconciler] Get UPDATE event for ReplicatedStorageClass %s. Check if it was changed.", e.ObjectNew.GetName()))
 			log.Trace(fmt.Sprintf("[ReplicatedStorageClassReconciler] Old ReplicatedStorageClass: %+v", e.ObjectOld))
 			log.Trace(fmt.Sprintf("[ReplicatedStorageClassReconciler] New ReplicatedStorageClass: %+v", e.ObjectNew))
-			if e.ObjectNew.GetDeletionTimestamp() != nil || !reflect.DeepEqual(e.ObjectNew.Spec, e.ObjectOld.Spec) || !reflect.DeepEqual(e.ObjectNew.Annotations, e.ObjectOld.Annotations) {
+			if e.ObjectNew.GetDeletionTimestamp() != nil ||
+				!reflect.DeepEqual(e.ObjectNew.Spec, e.ObjectOld.Spec) ||
+				!reflect.DeepEqual(e.ObjectNew.Annotations, e.ObjectOld.Annotations) ||
+				!reflect.DeepEqual(e.ObjectNew.Labels, e.ObjectOld.Labels) {
 				log.Debug(fmt.Sprintf("[ReplicatedStorageClassReconciler] ReplicatedStorageClass %s was changed. Add it to queue.", e.ObjectNew.GetName()))
 				request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: e.ObjectNew.GetNamespace(), Name: e.ObjectNew.GetName()}}
 				q.Add(request)

--- a/images/controller/pkg/controller/replicated_storage_class.go
+++ b/images/controller/pkg/controller/replicated_storage_class.go
@@ -540,7 +540,6 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *srv.Replicated
 			OwnerReferences: nil,
 			Finalizers:      []string{StorageClassFinalizerName},
 			ManagedFields:   nil,
-			Labels:          map[string]string{ManagedLabelKey: ManagedLabelValue},
 			Annotations:     map[string]string{RSCStorageClassVolumeSnapshotClassAnnotationKey: RSCStorageClassVolumeSnapshotClassAnnotationValue},
 		},
 		AllowVolumeExpansion: &allowVolumeExpansion,
@@ -548,6 +547,13 @@ func GenerateStorageClassFromReplicatedStorageClass(replicatedSC *srv.Replicated
 		Provisioner:          StorageClassProvisioner,
 		ReclaimPolicy:        &reclaimPolicy,
 		VolumeBindingMode:    &volumeBindingMode,
+	}
+
+	if replicatedSC.Labels != nil {
+		newStorageClass.Labels = replicatedSC.Labels
+		newStorageClass.Labels[ManagedLabelKey] = ManagedLabelValue
+	} else {
+		newStorageClass.Labels = map[string]string{ManagedLabelKey: ManagedLabelValue}
 	}
 
 	return newStorageClass


### PR DESCRIPTION
## Description
Propagate `metadata.labels` from `ReplicatedStorageClass` CR to the native Kubernetes `StorageClass`, following the same pattern as csi-ceph.

## Why do we need it, and what problem does it solve?
Users need to attach custom labels to StorageClasses (for monitoring, policy, or inventory). The sds-replicated-volume controller manages StorageClasses via Deckhouse CRs; without label propagation, labels set on the CR were not reflected on the actual StorageClass resource.

## What is the expected result?
After creating or updating a `ReplicatedStorageClass` with `metadata.labels`, the corresponding `StorageClass` has those labels plus `storage.deckhouse.io/managed-by`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.