### PR TITLE
[linstor-migrator] remove RSC lookup by RSP name

### DIFF
--- a/images/linstor-migrator/internal/migrator/migrator.go
+++ b/images/linstor-migrator/internal/migrator/migrator.go
@@ -439,7 +439,7 @@ func (m *Migrator) migrateResource(
 		return nil
 	}
 
-	rscName, rscOK := m.findReplicatedStorageClassForResource(pv, poolName, repStorClasses)
+	rscName, rscOK := m.findReplicatedStorageClassForResource(pv, repStorClasses)
 
 	sharedSecret, err := db.GetSharedSecret(resName)
 	if err != nil {
@@ -962,22 +962,14 @@ func (m *Migrator) ensureMigrationRSP(
 }
 
 // findReplicatedStorageClassForResource returns an existing ReplicatedStorageClass name when RV
-// should use Auto configuration (PV storage class name matches an RSC, or legacy pool match without PV).
+// should use Auto configuration (PV storage class name matches an RSC).
 func (m *Migrator) findReplicatedStorageClassForResource(
 	pv *corev1.PersistentVolume,
-	linstorPoolName string,
 	repStorClasses map[string]srvv1alpha1.ReplicatedStorageClass,
 ) (rscName string, ok bool) {
 	if pv != nil && pv.Spec.StorageClassName != "" {
 		if _, exists := repStorClasses[pv.Spec.StorageClassName]; exists {
 			return pv.Spec.StorageClassName, true
-		}
-		return "", false
-	}
-	for _, rsc := range repStorClasses {
-		// nolint:staticcheck // deprecated spec.storagePool still used for legacy pool binding
-		if strings.EqualFold(rsc.Spec.StoragePool, linstorPoolName) {
-			return rsc.Name, true
 		}
 	}
 	return "", false


### PR DESCRIPTION
## Description

The migrator used to search for a ReplicatedStorageClass (RSC) by matching the legacy spec.storagePool field with the LINSTOR storage pool name. However, this functionality is now obsolete because the controller's RSC conversion removes the RSP name.

Furthermore, this lookup contained a bug where the RSC selection could end up being incorrect if multiple RSCs referenced the same RSP.

With this change, the legacy pool name lookup is removed. As a result, ReplicatedVolumes from `resourcesWithoutPV` will no longer attempt to find an RSC by pool name and will correctly fallback to being created in manual mode.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
