### PR TITLE
[linstor-migrator] Preserve LINSTOR state: add offline viewer and backup legacy RSPs before deletion

### DIFF
--- a/e2e/linstor-migrator/tests/helpers/migration.go
+++ b/e2e/linstor-migrator/tests/helpers/migration.go
@@ -21,11 +21,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	. "github.com/onsi/ginkgo/v2"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -287,7 +288,9 @@ func WaitForMigrationComplete(ctx context.Context, c client.Client, timeout time
 
 // VerifyMigratorArtifactsOnMaster verifies that migrator artifacts exist on one
 // of the master/control-plane nodes and that required files/directories are
-// present with non-zero file sizes.
+// present with non-zero file sizes (including the linstor-viewer backup helper).
+// It also runs linstor-viewer against crs.gz for node list, storage-pool list,
+// and volume list; each command must exit 0 and print non-whitespace output.
 func VerifyMigratorArtifactsOnMaster(ctx context.Context, c client.Client, clientset kubernetes.Interface, restConfig *rest.Config) []error {
 	var nodeList corev1.NodeList
 	if err := c.List(ctx, &nodeList); err != nil {
@@ -322,12 +325,34 @@ test -d "${BASE}"
 test -d "${BASE}/linstor-backup-db"
 test -f "${BASE}/linstor-backup-db/crds.gz"
 test -f "${BASE}/linstor-backup-db/crs.gz"
+test -f "${BASE}/linstor-backup-db/linstor-viewer"
 test -f "${BASE}/linstor-backup-db/readme.txt"
 test -f "${BASE}/linstor-migrator.log"
 test -s "${BASE}/linstor-backup-db/crds.gz"
 test -s "${BASE}/linstor-backup-db/crs.gz"
+test -s "${BASE}/linstor-backup-db/linstor-viewer"
 test -s "${BASE}/linstor-backup-db/readme.txt"
 test -s "${BASE}/linstor-migrator.log"
+test -x "${BASE}/linstor-backup-db/linstor-viewer"
+`
+
+	viewerScript := `
+set -e
+BASE="/opt/deckhouse/tmp/linstor-migrator"
+V="${BASE}/linstor-backup-db/linstor-viewer"
+C="${BASE}/linstor-backup-db/crs.gz"
+for sub in "node list" "storage-pool list" "volume list"; do
+  set -- ${sub}
+  out=$("$V" "$C" "$@") || {
+    echo "linstor-viewer ${sub} failed" >&2
+    exit 1
+  }
+  trimmed=$(printf '%s' "$out" | tr -d '[:space:]')
+  if [ -z "${trimmed}" ]; then
+    echo "linstor-viewer ${sub} produced empty output" >&2
+    exit 1
+  fi
+done
 `
 
 	for _, nodeName := range masterNodes {
@@ -395,7 +420,26 @@ test -s "${BASE}/linstor-migrator.log"
 			)}
 		}
 
-		slog.Debug(fmt.Sprintf("PASS: Migrator artifacts found on master node %s with required non-empty files", nodeName))
+		viewerCmd := []string{
+			"/opt/deckhouse/sds/bin/nsenter.static", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--",
+			"sh", "-ec", viewerScript,
+		}
+		if _, err := execInPodWithOutputInContainer(
+			ctx,
+			clientset,
+			restConfig,
+			agentPodName,
+			"d8-sds-node-configurator",
+			"sds-node-configurator-agent",
+			viewerCmd,
+		); err != nil {
+			return []error{fmt.Errorf(
+				"linstor-viewer smoke check failed on master node %s via pod %s: %w",
+				nodeName, agentPodName, err,
+			)}
+		}
+
+		slog.Debug(fmt.Sprintf("PASS: Migrator artifacts and linstor-viewer listings verified on master node %s", nodeName))
 		return nil
 	}
 

--- a/images/linstor-migrator/README.md
+++ b/images/linstor-migrator/README.md
@@ -113,7 +113,7 @@ High-level flow:
 1. set state to `stage1_started`;
 2. wait until `Deployment/linstor-controller` disappears from `d8-sds-replicated-volume` (up to 10 minutes);
 3. if the LINSTOR CRD is missing, set `stage1_completed` and skip the rest of stage 1;
-4. discover every `CustomResourceDefinition` with `spec.group` `internal.linstor.linbit.com`, write their definitions to `crds.gz`, list all instances of each CRD and write them to `crs.gz`, and write `readme.txt` under `MigratorHostDir/MigratorLinstorBackupDirName` (default subdirectory name `linstor-backup-db`);
+4. discover every `CustomResourceDefinition` with `spec.group` `internal.linstor.linbit.com`, write their definitions to `crds.gz`, list all instances of each CRD and write them to `crs.gz`, install the `linstor-viewer` backup viewer binary, and write `readme.txt` under `MigratorHostDir/MigratorLinstorBackupDirName` (default subdirectory name `linstor-backup-db`);
 5. load LINSTOR data from CRDs into an in-memory snapshot;
 6. list `PersistentVolume`, `ReplicatedStorageClass`, `VolumeAttachment`, and `LVMVolumeGroup` objects;
 7. classify LINSTOR resources into:
@@ -257,3 +257,17 @@ data:
   state: not_started
 EOF
 ```
+
+## LINSTOR backup viewer (`linstor-viewer`)
+
+After stage 1, the backup directory contains a read-only helper binary `linstor-viewer` that prints LINSTOR-style listings reconstructed from `crs.gz` (no live LINSTOR controller required). Fields not stored in the CR backup are shown as `-`.
+
+```bash
+cd /opt/deckhouse/tmp/linstor-migrator/linstor-backup-db
+./linstor-viewer crs.gz node list
+./linstor-viewer crs.gz storage-pool list
+./linstor-viewer crs.gz volume list
+./linstor-viewer --help
+```
+
+To rebuild the embedded viewer when developing the migrator locally, see `internal/linstorbackup/embedded/README.md`.

--- a/images/linstor-migrator/README.md
+++ b/images/linstor-migrator/README.md
@@ -124,7 +124,7 @@ High-level flow:
 9. migrate resources with PVs first, then resources without PVs;
 10. delete every `CustomResourceDefinition` with `spec.group` `internal.linstor.linbit.com` (cluster data was backed up in step 4);
 11. delete all `ReplicatedStorageMetadataBackup` objects (cluster-held LINSTOR metadata backups);
-12. delete legacy `ReplicatedStoragePool` objects whose names equal a migrated LINSTOR storage pool name (skips `linstor-auto-*` and `auto-rsp-*`);
+12. back up legacy `ReplicatedStoragePool` objects (name = LINSTOR pool, skips `linstor-auto-*` and `auto-rsp-*`) to `legacy-rsp.gz` when any exist, then delete them;
 13. set state to `stage1_completed`.
 
 ### Stage 2
@@ -187,7 +187,7 @@ Current behavior:
 
 If the migrator cannot resolve the corresponding `LVMVolumeGroup` or thin pool for a LINSTOR pool, it fails fast.
 
-After stage 1 step 12, any `ReplicatedStoragePool` that was named exactly like a LINSTOR pool (typical for manually created pools on the old control plane) is removed. Pools created by this migrator (`linstor-auto-*`) or by the RSC controller (`auto-rsp-*`) are left in place.
+After stage 1 step 12, any `ReplicatedStoragePool` that was named exactly like a LINSTOR pool (typical for manually created pools on the old control plane) is written to `legacy-rsp.gz` in the backup directory (if present) and then removed. Pools created by this migrator (`linstor-auto-*`) or by the RSC controller (`auto-rsp-*`) are left in place. If no legacy pools exist, `legacy-rsp.gz` is not created.
 
 ## Created Resources
 

--- a/images/linstor-migrator/cmd/linstor-viewer/main.go
+++ b/images/linstor-migrator/cmd/linstor-viewer/main.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command linstor-viewer is installed as linstor-viewer next to migrator backups.
+package main
+
+import (
+	"os"
+
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/linstorviewer"
+)
+
+func main() {
+	os.Exit(linstorviewer.Run(os.Args[1:]))
+}

--- a/images/linstor-migrator/internal/config/config.go
+++ b/images/linstor-migrator/internal/config/config.go
@@ -31,7 +31,8 @@ const (
 	// MigratorLogFileName is the log file name inside MigratorHostDir (opened with O_APPEND).
 	MigratorLogFileName = "linstor-migrator.log"
 
-	// MigratorLinstorBackupDirName is the subdirectory under MigratorHostDir for LINSTOR CR YAML backup (crds.gz, crs.gz, linstor-viewer, readme.txt).
+	// MigratorLinstorBackupDirName is the subdirectory under MigratorHostDir for LINSTOR CR YAML backup
+	// (crds.gz, crs.gz, linstor-viewer, legacy-rsp.gz when present, readme.txt).
 	MigratorLinstorBackupDirName = "linstor-backup-db"
 
 	// MigrationConfigMapName is the name of the ConfigMap used to track migration state.

--- a/images/linstor-migrator/internal/config/config.go
+++ b/images/linstor-migrator/internal/config/config.go
@@ -31,7 +31,7 @@ const (
 	// MigratorLogFileName is the log file name inside MigratorHostDir (opened with O_APPEND).
 	MigratorLogFileName = "linstor-migrator.log"
 
-	// MigratorLinstorBackupDirName is the subdirectory under MigratorHostDir for LINSTOR CR YAML backup (crds.gz, readme.txt).
+	// MigratorLinstorBackupDirName is the subdirectory under MigratorHostDir for LINSTOR CR YAML backup (crds.gz, crs.gz, linstor-viewer, readme.txt).
 	MigratorLinstorBackupDirName = "linstor-backup-db"
 
 	// MigrationConfigMapName is the name of the ConfigMap used to track migration state.

--- a/images/linstor-migrator/internal/linstorbackup/backup.go
+++ b/images/linstor-migrator/internal/linstorbackup/backup.go
@@ -58,7 +58,7 @@ func backupReadmeText() string {
 	exampleDir := filepath.Join(config.MigratorHostDir, config.MigratorLinstorBackupDirName)
 	exampleCRDs := filepath.Join(exampleDir, backupCRDsGzFile)
 	exampleCRs := filepath.Join(exampleDir, backupCRsGzFile)
-	return fmt.Sprintf(`LINSTOR backup (API group internal.linstor.linbit.com)
+	return fmt.Sprintf(`LINSTOR backup
 ========================================================
 
 Files:
@@ -66,6 +66,8 @@ Files:
             (spec.group internal.linstor.linbit.com).
   crs.gz  — gzip multi-document YAML: every custom resource instance for those CRDs.
   linstor-viewer — helper binary to print LINSTOR-style listings from crs.gz (read-only).
+  legacy-rsp.gz — gzip multi-document YAML of legacy ReplicatedStoragePool objects removed during
+                  migration (only created when such pools exist).
 
 Restore:
   1. mkdir -p /tmp/linstor-restore && cd /tmp/linstor-restore
@@ -73,6 +75,9 @@ Restore:
   3. kubectl apply -f crds.yaml
   4. gunzip -c %s > crs.yaml
   5. kubectl apply -f crs.yaml
+
+Restore legacy ReplicatedStoragePool (if legacy-rsp.gz exists):
+  gunzip -c <backup-dir>/legacy-rsp.gz | kubectl apply -f -
 
 View cluster snapshot (from backup directory):
   ./linstor-viewer crs.gz node list
@@ -83,7 +88,6 @@ View cluster snapshot (from backup directory):
 Notes:
   - Apply CRDs before CRs. Status and server-owned metadata (managedFields, resourceVersion, uid,
     creationTimestamp, generation) are omitted from both files so manifests are apply-friendly.
-  - Listings are reconstructed from CR data; fields not present in the backup show "-".
 `, exampleCRDs, exampleCRs)
 }
 

--- a/images/linstor-migrator/internal/linstorbackup/backup.go
+++ b/images/linstor-migrator/internal/linstorbackup/backup.go
@@ -65,6 +65,7 @@ Files:
   crds.gz — gzip multi-document YAML: one CustomResourceDefinition per document
             (spec.group internal.linstor.linbit.com).
   crs.gz  — gzip multi-document YAML: every custom resource instance for those CRDs.
+  linstor-viewer — helper binary to print LINSTOR-style listings from crs.gz (read-only).
 
 Restore:
   1. mkdir -p /tmp/linstor-restore && cd /tmp/linstor-restore
@@ -73,9 +74,16 @@ Restore:
   4. gunzip -c %s > crs.yaml
   5. kubectl apply -f crs.yaml
 
+View cluster snapshot (from backup directory):
+  ./linstor-viewer crs.gz node list
+  ./linstor-viewer crs.gz storage-pool list
+  ./linstor-viewer crs.gz volume list
+  ./linstor-viewer --help
+
 Notes:
   - Apply CRDs before CRs. Status and server-owned metadata (managedFields, resourceVersion, uid,
     creationTimestamp, generation) are omitted from both files so manifests are apply-friendly.
+  - Listings are reconstructed from CR data; fields not present in the backup show "-".
 `, exampleCRDs, exampleCRs)
 }
 
@@ -175,6 +183,10 @@ func WriteGroupBackup(ctx context.Context, kClient client.Client, dyn dynamic.In
 	}
 	if err := deduplicateBackups(log, dir, backupCRsGzFile); err != nil {
 		return fmt.Errorf("deduplicate CR backups: %w", err)
+	}
+
+	if err := InstallLinstorViewer(dir); err != nil {
+		return fmt.Errorf("install linstor backup viewer: %w", err)
 	}
 
 	readmePath := filepath.Join(dir, backupReadme)

--- a/images/linstor-migrator/internal/linstorbackup/embed.go
+++ b/images/linstor-migrator/internal/linstorbackup/embed.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linstorbackup
+
+import _ "embed"
+
+//go:embed embedded/linstor-viewer
+var embeddedLinstor []byte

--- a/images/linstor-migrator/internal/linstorbackup/embedded/.gitignore
+++ b/images/linstor-migrator/internal/linstorbackup/embedded/.gitignore
@@ -1,0 +1,1 @@
+linstor-viewer

--- a/images/linstor-migrator/internal/linstorbackup/embedded/README.md
+++ b/images/linstor-migrator/internal/linstorbackup/embedded/README.md
@@ -1,0 +1,27 @@
+# Embedded `linstor-viewer` binary
+
+The file `linstor-viewer` is produced at image/build time and embedded into the migrator binary via `go:embed`. Do not commit the binary (see `.gitignore`).
+
+## Werf / CI
+
+`images/linstor-migrator/werf.inc.yaml` builds the viewer first, copies it here, then builds the migrator so `go:embed` succeeds.
+
+## Local development
+
+From the repository root:
+
+```bash
+cd images/linstor-migrator
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" \
+  -o internal/linstorbackup/embedded/linstor-viewer ./cmd/linstor-viewer
+chmod 0755 internal/linstorbackup/embedded/linstor-viewer
+```
+
+Then build or test the migrator as usual, for example:
+
+```bash
+go test ./...
+go build -o /tmp/linstor-migrator ./cmd
+```
+
+Without `embedded/linstor-viewer`, `go build` of the migrator fails on the embed directive.

--- a/images/linstor-migrator/internal/linstorbackup/install_viewer.go
+++ b/images/linstor-migrator/internal/linstorbackup/install_viewer.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linstorbackup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const backupLinstorViewerFile = "linstor-viewer"
+
+// InstallLinstorViewer writes the embedded linstor backup viewer binary into dir.
+func InstallLinstorViewer(dir string) error {
+	if len(embeddedLinstor) == 0 {
+		return fmt.Errorf("embedded linstor viewer binary is empty (see internal/linstorbackup/embedded/README.md or build via werf)")
+	}
+	path := filepath.Join(dir, backupLinstorViewerFile)
+	if err := os.WriteFile(path, embeddedLinstor, 0o755); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return nil
+}

--- a/images/linstor-migrator/internal/linstorbackup/legacy_rsp.go
+++ b/images/linstor-migrator/internal/linstorbackup/legacy_rsp.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linstorbackup
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	srvv1alpha1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/config"
+)
+
+const backupLegacyRSPGzFile = "legacy-rsp.gz"
+
+// IsLegacyReplicatedStoragePoolCandidate reports whether poolName may refer to a legacy
+// ReplicatedStoragePool removed after migration (excludes migrator/RSC auto-created names).
+func IsLegacyReplicatedStoragePoolCandidate(poolName string) bool {
+	if poolName == "" {
+		return false
+	}
+	if strings.HasPrefix(poolName, config.AutoReplicatedStoragePoolNamePrefix) {
+		return false
+	}
+	if strings.HasPrefix(poolName, config.AutoReplicatedStoragePoolRSCNamePrefix) {
+		return false
+	}
+	return true
+}
+
+// WriteLegacyRSPBackup loads legacy ReplicatedStoragePool objects by name, writes legacy-rsp.gz
+// when at least one exists, and returns the names that were backed up (for a subsequent delete pass).
+// No file is created when nothing is found.
+func WriteLegacyRSPBackup(
+	ctx context.Context,
+	kClient client.Client,
+	log *slog.Logger,
+	dir string,
+	linstorPoolNames []string,
+) ([]string, error) {
+	var backedUp []srvv1alpha1.ReplicatedStoragePool
+
+	seen := make(map[string]struct{})
+	for _, poolName := range linstorPoolNames {
+		if !IsLegacyReplicatedStoragePoolCandidate(poolName) {
+			continue
+		}
+		if _, ok := seen[poolName]; ok {
+			continue
+		}
+		seen[poolName] = struct{}{}
+
+		rsp := &srvv1alpha1.ReplicatedStoragePool{}
+		if err := kClient.Get(ctx, client.ObjectKey{Name: poolName}, rsp); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("get legacy ReplicatedStoragePool %q: %w", poolName, err)
+		}
+		backedUp = append(backedUp, *rsp.DeepCopy())
+	}
+
+	if len(backedUp) == 0 {
+		log.Debug("no legacy ReplicatedStoragePool objects to back up")
+		return nil, nil
+	}
+
+	sort.Slice(backedUp, func(i, j int) bool {
+		return backedUp[i].Name < backedUp[j].Name
+	})
+
+	var yamlBuf bytes.Buffer
+	for i := range backedUp {
+		b, err := rspToApplyFriendlyYAML(&backedUp[i])
+		if err != nil {
+			return nil, fmt.Errorf("marshal legacy ReplicatedStoragePool %q: %w", backedUp[i].Name, err)
+		}
+		if i > 0 {
+			yamlBuf.WriteString("---\n")
+		}
+		yamlBuf.Write(b)
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create backup directory %q: %w", dir, err)
+	}
+
+	path := getNextFilePath(filepath.Join(dir, backupLegacyRSPGzFile))
+	if err := writeGzipFile(path, yamlBuf.Bytes()); err != nil {
+		return nil, err
+	}
+	if err := deduplicateBackups(log, dir, backupLegacyRSPGzFile); err != nil {
+		return nil, fmt.Errorf("deduplicate legacy RSP backups: %w", err)
+	}
+
+	names := make([]string, len(backedUp))
+	for i := range backedUp {
+		names[i] = backedUp[i].Name
+	}
+	log.Info("wrote legacy ReplicatedStoragePool backup", "file", backupLegacyRSPGzFile, "count", len(names))
+	return names, nil
+}
+
+func rspToApplyFriendlyYAML(rsp *srvv1alpha1.ReplicatedStoragePool) ([]byte, error) {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(rsp.DeepCopy())
+	if err != nil {
+		return nil, err
+	}
+	stripApplyUnfriendlyFields(u)
+	u["apiVersion"] = srvv1alpha1.SchemeGroupVersion.String()
+	u["kind"] = "ReplicatedStoragePool"
+	return yaml.Marshal(u)
+}

--- a/images/linstor-migrator/internal/linstorbackup/legacy_rsp_test.go
+++ b/images/linstor-migrator/internal/linstorbackup/legacy_rsp_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linstorbackup
+
+import (
+	"compress/gzip"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	srvv1alpha1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/config"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := srvv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return s
+}
+
+func TestIsLegacyReplicatedStoragePoolCandidate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		label    string
+		poolName string
+		want     bool
+	}{
+		{"empty", "", false},
+		{"legacy", "thick-data", true},
+		{"linstor-auto", config.AutoReplicatedStoragePoolNamePrefix + "foo", false},
+		{"auto-rsp", config.AutoReplicatedStoragePoolRSCNamePrefix + "foo", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+			if got := IsLegacyReplicatedStoragePoolCandidate(tc.poolName); got != tc.want {
+				t.Fatalf("IsLegacyReplicatedStoragePoolCandidate(%q) = %v, want %v", tc.poolName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteLegacyRSPBackup_skipsWhenNoneExist(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cl := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	names, err := WriteLegacyRSPBackup(context.Background(), cl, slog.Default(), dir, []string{"thick-data", "missing-pool"})
+	if err != nil {
+		t.Fatalf("WriteLegacyRSPBackup: %v", err)
+	}
+	if names != nil {
+		t.Fatalf("expected nil names, got %v", names)
+	}
+	if _, err := os.Stat(filepath.Join(dir, backupLegacyRSPGzFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected no %s, stat err=%v", backupLegacyRSPGzFile, err)
+	}
+}
+
+func TestWriteLegacyRSPBackup_writesGzipMultiDoc(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	legacy := &srvv1alpha1.ReplicatedStoragePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "thick-data"},
+		Spec: srvv1alpha1.ReplicatedStoragePoolSpec{
+			Type: srvv1alpha1.ReplicatedStoragePoolTypeLVM,
+			LVMVolumeGroups: []srvv1alpha1.ReplicatedStoragePoolLVMVolumeGroups{
+				{Name: "lvg-1"},
+			},
+		},
+		Status: srvv1alpha1.ReplicatedStoragePoolStatus{
+			Phase: srvv1alpha1.ReplicatedStoragePoolPhaseReady,
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(legacy).Build()
+
+	names, err := WriteLegacyRSPBackup(context.Background(), cl, slog.Default(), dir, []string{
+		"thick-data",
+		config.AutoReplicatedStoragePoolNamePrefix + "skip",
+		"thick-data",
+	})
+	if err != nil {
+		t.Fatalf("WriteLegacyRSPBackup: %v", err)
+	}
+	if len(names) != 1 || names[0] != "thick-data" {
+		t.Fatalf("names: %v", names)
+	}
+
+	f, err := os.Open(filepath.Join(dir, backupLegacyRSPGzFile))
+	if err != nil {
+		t.Fatalf("open backup: %v", err)
+	}
+	defer f.Close()
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	defer gzr.Close()
+	body, err := io.ReadAll(gzr)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "kind: ReplicatedStoragePool") {
+		t.Fatalf("missing kind in backup:\n%s", text)
+	}
+	if !strings.Contains(text, "name: thick-data") {
+		t.Fatalf("missing name in backup:\n%s", text)
+	}
+	if strings.Contains(text, "status:") {
+		t.Fatalf("status should be stripped:\n%s", text)
+	}
+}

--- a/images/linstor-migrator/internal/linstorviewer/index/index.go
+++ b/images/linstor-migrator/internal/linstorviewer/index/index.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package index builds lookup tables from LINSTOR CR documents for CLI-style listings.
+package index
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	kindNodes                      = "Nodes"
+	kindNodeNetInterfaces          = "NodeNetInterfaces"
+	kindNodeStorPool               = "NodeStorPool"
+	kindStorPoolDefinitions        = "StorPoolDefinitions"
+	kindPropsContainers            = "PropsContainers"
+	kindVolumes                    = "Volumes"
+	kindLayerResourceIds           = "LayerResourceIds"
+	kindLayerStorageVolumes        = "LayerStorageVolumes"
+	kindLayerDrbdVolumeDefinitions = "LayerDrbdVolumeDefinitions"
+
+	storDriverStorPoolNameKey = "StorDriver/StorPoolName"
+	layerResourceKindStorage  = "STORAGE"
+)
+
+// Store holds derived indexes from a crs.gz snapshot.
+type Store struct {
+	// nodeDSP maps LINSTOR node_name (any case) to display name (node_dsp_name).
+	nodeDSP map[string]string
+	// poolDSP maps LINSTOR pool_name (any case) to display name (pool_dsp_name).
+	poolDSP map[string]string
+	// storPoolPhys maps normalized node+pool to StorDriver/StorPoolName value.
+	storPoolPhys map[string]string
+	// storageVolByLRID maps layer_resource_id to storage pool display name on that volume.
+	storageVolByLRID map[int]storageVolInfo
+	// drbdMinor maps resource_name+vlm_nr (lowercase) to minor number.
+	drbdMinor map[string]int
+
+	nodes        []NodeRow
+	storagePools []StoragePoolRow
+	volumes      []VolumeRow
+}
+
+type storageVolInfo struct {
+	storPoolDSP string
+}
+
+// NodeRow is one line of node list output.
+type NodeRow struct {
+	Node      string
+	NodeType  string
+	Addresses string
+	State     string
+}
+
+// StoragePoolRow is one line of storage-pool list output.
+type StoragePoolRow struct {
+	StoragePool string
+	Node        string
+	Driver      string
+	PoolName    string
+	State       string
+}
+
+// VolumeRow is one line of volume list output.
+type VolumeRow struct {
+	Node        string
+	Resource    string
+	StoragePool string
+	VolNr       string
+	MinorNr     string
+	DeviceName  string
+	InUse       string
+	State       string
+}
+
+// Build constructs indexes and pre-rendered row slices from backup documents.
+func Build(docs []*unstructured.Unstructured) (*Store, error) {
+	s := &Store{
+		nodeDSP:          make(map[string]string),
+		poolDSP:          make(map[string]string),
+		storPoolPhys:     make(map[string]string),
+		storageVolByLRID: make(map[int]storageVolInfo),
+		drbdMinor:        make(map[string]int),
+	}
+
+	byKind := make(map[string][]*unstructured.Unstructured)
+	for _, d := range docs {
+		byKind[d.GetKind()] = append(byKind[d.GetKind()], d)
+	}
+
+	for _, u := range byKind[kindNodes] {
+		name := specString(u, "node_name")
+		dsp := specString(u, "node_dsp_name")
+		if name == "" {
+			continue
+		}
+		if dsp == "" {
+			dsp = strings.ToLower(name)
+		}
+		s.nodeDSP[normalizeKey(name)] = dsp
+	}
+
+	for _, u := range byKind[kindStorPoolDefinitions] {
+		name := specString(u, "pool_name")
+		dsp := specString(u, "pool_dsp_name")
+		if name == "" {
+			continue
+		}
+		if dsp == "" {
+			dsp = name
+		}
+		s.poolDSP[normalizeKey(name)] = dsp
+	}
+
+	for _, u := range byKind[kindPropsContainers] {
+		if specString(u, "prop_key") != storDriverStorPoolNameKey {
+			continue
+		}
+		nodeName, poolName, ok := parseStorPoolConfInstance(specString(u, "props_instance"))
+		if !ok {
+			continue
+		}
+		s.storPoolPhys[normalizeStorPoolKey(nodeName, poolName)] = specString(u, "prop_value")
+	}
+
+	for _, u := range byKind[kindLayerStorageVolumes] {
+		lrid, _, _ := unstructured.NestedInt64(u.Object, "spec", "layer_resource_id")
+		s.storageVolByLRID[int(lrid)] = storageVolInfo{
+			storPoolDSP: s.poolDisplay(specString(u, "stor_pool_name")),
+		}
+	}
+
+	for _, u := range byKind[kindLayerDrbdVolumeDefinitions] {
+		res := specString(u, "resource_name")
+		vlmNr, _, _ := unstructured.NestedInt64(u.Object, "spec", "vlm_nr")
+		minor, _, _ := unstructured.NestedInt64(u.Object, "spec", "vlm_minor_nr")
+		key := volumeKey(res, int(vlmNr))
+		s.drbdMinor[key] = int(minor)
+	}
+
+	s.buildNodes(byKind[kindNodes], byKind[kindNodeNetInterfaces])
+	s.buildStoragePools(byKind[kindNodeStorPool])
+	s.buildVolumes(byKind[kindVolumes], byKind[kindLayerResourceIds])
+
+	return s, nil
+}
+
+func (s *Store) buildNodes(nodes, netIfaces []*unstructured.Unstructured) {
+	addrByNode := make(map[string][]string)
+	for _, u := range netIfaces {
+		node := specString(u, "node_name")
+		ip := specString(u, "inet_address")
+		port, _, _ := unstructured.NestedInt64(u.Object, "spec", "stlt_conn_port")
+		encr := specString(u, "stlt_conn_encr_type")
+		if node == "" || ip == "" {
+			continue
+		}
+		addr := fmt.Sprintf("%s:%d", ip, port)
+		if encr != "" {
+			addr += " (" + encr + ")"
+		}
+		addrByNode[normalizeKey(node)] = append(addrByNode[normalizeKey(node)], addr)
+	}
+
+	for _, u := range nodes {
+		name := specString(u, "node_name")
+		dsp := s.nodeDisplay(name)
+		nodeType := nodeTypeDisplay(u)
+		addrs := strings.Join(addrByNode[normalizeKey(name)], ", ")
+		if addrs == "" {
+			addrs = dash
+		}
+		s.nodes = append(s.nodes, NodeRow{
+			Node:      dsp,
+			NodeType:  nodeType,
+			Addresses: addrs,
+			State:     dash,
+		})
+	}
+
+	sort.Slice(s.nodes, func(i, j int) bool {
+		return s.nodes[i].Node < s.nodes[j].Node
+	})
+}
+
+func (s *Store) buildStoragePools(pools []*unstructured.Unstructured) {
+	for _, u := range pools {
+		nodeName := specString(u, "node_name")
+		poolName := specString(u, "pool_name")
+		driver := specString(u, "driver_name")
+		phys := s.storPoolPhys[normalizeStorPoolKey(nodeName, poolName)]
+		if phys == "" {
+			phys = dash
+		}
+		s.storagePools = append(s.storagePools, StoragePoolRow{
+			StoragePool: s.poolDisplay(poolName),
+			Node:        s.nodeDisplay(nodeName),
+			Driver:      orDash(driver),
+			PoolName:    phys,
+			State:       dash,
+		})
+	}
+
+	sort.Slice(s.storagePools, func(i, j int) bool {
+		if s.storagePools[i].StoragePool != s.storagePools[j].StoragePool {
+			return s.storagePools[i].StoragePool < s.storagePools[j].StoragePool
+		}
+		return s.storagePools[i].Node < s.storagePools[j].Node
+	})
+}
+
+func (s *Store) buildVolumes(volumes, layerIDs []*unstructured.Unstructured) {
+	storageLRID := make(map[string]int)
+	for _, u := range layerIDs {
+		if !strings.EqualFold(specString(u, "layer_resource_kind"), layerResourceKindStorage) {
+			continue
+		}
+		res := specString(u, "resource_name")
+		node := specString(u, "node_name")
+		vlmNr, _, _ := unstructured.NestedInt64(u.Object, "spec", "vlm_nr")
+		lrid, _, _ := unstructured.NestedInt64(u.Object, "spec", "layer_resource_id")
+		storageLRID[volumeInstanceKey(node, res, int(vlmNr))] = int(lrid)
+	}
+
+	for _, u := range volumes {
+		nodeName := specString(u, "node_name")
+		resName := specString(u, "resource_name")
+		vlmNr, _, _ := unstructured.NestedInt64(u.Object, "spec", "vlm_nr")
+
+		pool := dash
+		if lrid, ok := storageLRID[volumeInstanceKey(nodeName, resName, int(vlmNr))]; ok {
+			if info, ok := s.storageVolByLRID[lrid]; ok && info.storPoolDSP != "" {
+				pool = info.storPoolDSP
+			}
+		}
+
+		minor := dash
+		device := dash
+		if m, ok := s.drbdMinor[volumeKey(resName, int(vlmNr))]; ok && m > 0 {
+			minor = fmt.Sprintf("%d", m)
+			device = fmt.Sprintf("/dev/drbd%d", m)
+		}
+
+		s.volumes = append(s.volumes, VolumeRow{
+			Node:        s.nodeDisplay(nodeName),
+			Resource:    strings.ToLower(resName),
+			StoragePool: pool,
+			VolNr:       fmt.Sprintf("%d", vlmNr),
+			MinorNr:     minor,
+			DeviceName:  device,
+			InUse:       dash,
+			State:       dash,
+		})
+	}
+
+	sort.Slice(s.volumes, func(i, j int) bool {
+		if s.volumes[i].Resource != s.volumes[j].Resource {
+			return s.volumes[i].Resource < s.volumes[j].Resource
+		}
+		if s.volumes[i].Node != s.volumes[j].Node {
+			return s.volumes[i].Node < s.volumes[j].Node
+		}
+		return s.volumes[i].VolNr < s.volumes[j].VolNr
+	})
+}
+
+func (s *Store) nodeDisplay(nodeName string) string {
+	if dsp, ok := s.nodeDSP[normalizeKey(nodeName)]; ok && dsp != "" {
+		return dsp
+	}
+	if nodeName == "" {
+		return dash
+	}
+	return strings.ToLower(nodeName)
+}
+
+func (s *Store) poolDisplay(poolName string) string {
+	if dsp, ok := s.poolDSP[normalizeKey(poolName)]; ok && dsp != "" {
+		return dsp
+	}
+	if poolName == "" {
+		return dash
+	}
+	return poolName
+}
+
+// Nodes returns node list rows.
+func (s *Store) Nodes() []NodeRow { return s.nodes }
+
+// StoragePools returns storage pool list rows.
+func (s *Store) StoragePools() []StoragePoolRow { return s.storagePools }
+
+// Volumes returns volume list rows.
+func (s *Store) Volumes() []VolumeRow { return s.volumes }
+
+const dash = "-"
+
+func specString(u *unstructured.Unstructured, key string) string {
+	v, _, _ := unstructured.NestedString(u.Object, "spec", key)
+	return v
+}
+
+func normalizeKey(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func normalizeStorPoolKey(nodeName, poolName string) string {
+	return normalizeKey(nodeName) + "\x00" + normalizeKey(poolName)
+}
+
+func parseStorPoolConfInstance(propsInstance string) (nodeName, poolName string, ok bool) {
+	parts := strings.Split(strings.Trim(propsInstance, "/"), "/")
+	if len(parts) < 3 {
+		return "", "", false
+	}
+	if !strings.EqualFold(parts[0], "STORPOOLCONF") {
+		return "", "", false
+	}
+	nodeName = parts[1]
+	if len(parts) == 3 {
+		return nodeName, parts[2], true
+	}
+	return nodeName, strings.Join(parts[2:], "/"), true
+}
+
+func volumeKey(resourceName string, vlmNr int) string {
+	return normalizeKey(resourceName) + "\x00" + fmt.Sprintf("%d", vlmNr)
+}
+
+func volumeInstanceKey(nodeName, resourceName string, vlmNr int) string {
+	return normalizeKey(nodeName) + "\x00" + volumeKey(resourceName, vlmNr)
+}
+
+func nodeTypeDisplay(u *unstructured.Unstructured) string {
+	t, _, _ := unstructured.NestedInt64(u.Object, "spec", "node_type")
+	switch t {
+	case 1:
+		return "CONTROLLER"
+	case 2:
+		return "SATELLITE"
+	case 3:
+		return "COMBINED"
+	default:
+		if t == 0 {
+			return dash
+		}
+		return fmt.Sprintf("%d", t)
+	}
+}
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return dash
+	}
+	return s
+}

--- a/images/linstor-migrator/internal/linstorviewer/index/index_test.go
+++ b/images/linstor-migrator/internal/linstorviewer/index/index_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/linstorviewer/load"
+)
+
+func TestBuildFromMinimalFixture(t *testing.T) {
+	path := filepath.Join("..", "testdata", "minimal-crs.yaml")
+	docs, err := load.FromFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	store, err := Build(docs)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	nodes := store.Nodes()
+	if len(nodes) != 1 {
+		t.Fatalf("nodes: got %d, want 1", len(nodes))
+	}
+	if nodes[0].Node != "node-a" {
+		t.Errorf("node display: got %q, want node-a", nodes[0].Node)
+	}
+	if !strings.Contains(nodes[0].Addresses, "10.0.0.1:3367") {
+		t.Errorf("addresses: got %q", nodes[0].Addresses)
+	}
+
+	pools := store.StoragePools()
+	if len(pools) != 1 {
+		t.Fatalf("pools: got %d, want 1", len(pools))
+	}
+	if pools[0].StoragePool != "pool-a" || pools[0].PoolName != "vg0" {
+		t.Errorf("pool row: %+v", pools[0])
+	}
+
+	vols := store.Volumes()
+	if len(vols) != 1 {
+		t.Fatalf("volumes: got %d, want 1", len(vols))
+	}
+	if vols[0].Resource != "pvc-test" {
+		t.Errorf("resource: got %q", vols[0].Resource)
+	}
+	if vols[0].MinorNr != "1000" || vols[0].DeviceName != "/dev/drbd1000" {
+		t.Errorf("drbd: minor=%q device=%q", vols[0].MinorNr, vols[0].DeviceName)
+	}
+}
+
+func TestBuildFromGzipFixtureOptional(t *testing.T) {
+	path := os.Getenv("LINSTOR_CRS_BACKUP")
+	if path == "" {
+		path = "/tmp/crs.gz"
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Skip("no crs.gz at", path)
+	}
+	docs, err := load.FromFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	store, err := Build(docs)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(store.Nodes()) == 0 {
+		t.Error("expected nodes from real backup")
+	}
+}

--- a/images/linstor-migrator/internal/linstorviewer/load/crs.go
+++ b/images/linstor-migrator/internal/linstorviewer/load/crs.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package load reads gzipped multi-document LINSTOR CR YAML backups (crs.gz).
+package load
+
+import (
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// FromFile opens path (plain YAML or .gz) and returns all documents.
+func FromFile(path string) ([]*unstructured.Unstructured, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open backup %q: %w", path, err)
+	}
+	defer f.Close()
+
+	var r io.Reader = f
+	if strings.HasSuffix(path, ".gz") {
+		gzr, err := gzip.NewReader(f)
+		if err != nil {
+			return nil, fmt.Errorf("gzip open %q: %w", path, err)
+		}
+		defer gzr.Close()
+		r = gzr
+	}
+
+	return decodeMultiDoc(r)
+}
+
+func decodeMultiDoc(r io.Reader) ([]*unstructured.Unstructured, error) {
+	yr := yaml.NewYAMLReader(bufio.NewReader(r))
+	var out []*unstructured.Unstructured
+
+	for {
+		doc, err := yr.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("read YAML document: %w", err)
+		}
+		if len(strings.TrimSpace(string(doc))) == 0 {
+			continue
+		}
+
+		var u unstructured.Unstructured
+		if err := yaml.Unmarshal(doc, &u); err != nil {
+			return nil, fmt.Errorf("parse YAML document: %w", err)
+		}
+		if u.GetKind() == "" {
+			continue
+		}
+		out = append(out, &u)
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no Kubernetes resources found in backup")
+	}
+	return out, nil
+}

--- a/images/linstor-migrator/internal/linstorviewer/render/lists.go
+++ b/images/linstor-migrator/internal/linstorviewer/render/lists.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/linstorviewer/index"
+)
+
+// NodeList formats node list output (linstor node list).
+func NodeList(store *index.Store) string {
+	rows := store.Nodes()
+	data := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		data = append(data, []string{r.Node, r.NodeType, r.Addresses, r.State})
+	}
+	return formatTable([]string{"Node", "NodeType", "Addresses", "State"}, data)
+}
+
+// StoragePoolList formats storage-pool list output.
+func StoragePoolList(store *index.Store) string {
+	rows := store.StoragePools()
+	data := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		data = append(data, []string{r.StoragePool, r.Node, r.Driver, r.PoolName, r.State})
+	}
+	return formatTable([]string{"StoragePool", "Node", "Driver", "PoolName", "State"}, data)
+}
+
+// VolumeList formats volume list output.
+func VolumeList(store *index.Store) string {
+	rows := store.Volumes()
+	data := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		data = append(data, []string{
+			r.Node, r.Resource, r.StoragePool, r.VolNr, r.MinorNr, r.DeviceName, r.InUse, r.State,
+		})
+	}
+	return formatTable([]string{
+		"Node", "Resource", "StoragePool", "VolNr", "MinorNr", "DeviceName", "InUse", "State",
+	}, data)
+}

--- a/images/linstor-migrator/internal/linstorviewer/render/table.go
+++ b/images/linstor-migrator/internal/linstorviewer/render/table.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+)
+
+func formatTable(headers []string, rows [][]string) string {
+	if len(rows) == 0 {
+		return "(empty)\n"
+	}
+
+	var b strings.Builder
+	w := tabwriter.NewWriter(&b, 0, 2, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, strings.Join(headers, "\t"))
+	for _, row := range rows {
+		_, _ = fmt.Fprintln(w, strings.Join(row, "\t"))
+	}
+	_ = w.Flush()
+	return b.String()
+}

--- a/images/linstor-migrator/internal/linstorviewer/testdata/minimal-crs.yaml
+++ b/images/linstor-migrator/internal/linstorviewer/testdata/minimal-crs.yaml
@@ -1,0 +1,83 @@
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Nodes
+metadata:
+  name: node-a-hash
+spec:
+  node_dsp_name: node-a
+  node_name: NODE-A
+  node_type: 2
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: NodeNetInterfaces
+metadata:
+  name: net-a
+spec:
+  inet_address: 10.0.0.1
+  node_name: NODE-A
+  stlt_conn_encr_type: SSL
+  stlt_conn_port: 3367
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: StorPoolDefinitions
+metadata:
+  name: spd-a
+spec:
+  pool_dsp_name: pool-a
+  pool_name: POOL-A
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: NodeStorPool
+metadata:
+  name: nsp-a
+spec:
+  driver_name: LVM
+  node_name: NODE-A
+  pool_name: POOL-A
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: PropsContainers
+metadata:
+  name: prop-a
+spec:
+  prop_key: StorDriver/StorPoolName
+  prop_value: vg0
+  props_instance: /STORPOOLCONF/NODE-A/POOL-A
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: LayerDrbdVolumeDefinitions
+metadata:
+  name: ldvd-a
+spec:
+  resource_name: PVC-TEST
+  vlm_minor_nr: 1000
+  vlm_nr: 0
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: LayerResourceIds
+metadata:
+  name: lrid-storage
+spec:
+  layer_resource_id: 10
+  layer_resource_kind: STORAGE
+  node_name: NODE-A
+  resource_name: PVC-TEST
+  vlm_nr: 0
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: LayerStorageVolumes
+metadata:
+  name: lsv-a
+spec:
+  layer_resource_id: 10
+  node_name: NODE-A
+  stor_pool_name: POOL-A
+  vlm_nr: 0
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Volumes
+metadata:
+  name: vol-a
+spec:
+  node_name: NODE-A
+  resource_name: PVC-TEST
+  vlm_nr: 0

--- a/images/linstor-migrator/internal/linstorviewer/viewer.go
+++ b/images/linstor-migrator/internal/linstorviewer/viewer.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package linstorviewer renders LINSTOR CLI-style listings from crs.gz backups.
+package linstorviewer
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/linstorviewer/index"
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/linstorviewer/load"
+	"github.com/deckhouse/sds-replicated-volume/images/linstor-migrator/internal/linstorviewer/render"
+)
+
+const (
+	cmdNodeList        = "node list"
+	cmdStoragePoolList = "storage-pool list"
+	cmdVolumeList      = "volume list"
+)
+
+// Run executes the linstor backup viewer CLI. args is os.Args[1:].
+func Run(args []string) int {
+	if len(args) == 0 || isHelp(args[0]) {
+		printUsage(os.Stdout)
+		return 0
+	}
+
+	if len(args) == 1 {
+		if isHelp(args[0]) {
+			printUsage(os.Stdout)
+			return 0
+		}
+		fmt.Fprintf(os.Stderr, "missing command after backup file\n\n")
+		printUsage(os.Stderr)
+		return 2
+	}
+
+	crsPath := args[0]
+	if isHelp(crsPath) {
+		printUsage(os.Stdout)
+		return 0
+	}
+
+	cmdArgs := args[1:]
+	for _, a := range cmdArgs {
+		if isHelp(a) {
+			printUsage(os.Stdout)
+			return 0
+		}
+	}
+
+	cmd := strings.Join(cmdArgs, " ")
+	docs, err := load.FromFile(crsPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	store, err := index.Build(docs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	var out string
+	switch cmd {
+	case cmdNodeList:
+		out = render.NodeList(store)
+	case cmdStoragePoolList:
+		out = render.StoragePoolList(store)
+	case cmdVolumeList:
+		out = render.VolumeList(store)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", cmd)
+		printUsage(os.Stderr)
+		return 2
+	}
+
+	fmt.Print(out)
+	return 0
+}
+
+func isHelp(s string) bool {
+	return s == "-h" || s == "--help" || s == "-help"
+}
+
+func printUsage(w *os.File) {
+	_, _ = fmt.Fprintf(w, `linstor-viewer — read-only LINSTOR listings from a migrator crs.gz backup
+
+Usage:
+  linstor-viewer [-h|--help]
+  linstor-viewer <crs.gz> [-h|--help]
+  linstor-viewer <crs.gz> node list
+  linstor-viewer <crs.gz> storage-pool list
+  linstor-viewer <crs.gz> volume list
+
+The backup is a snapshot of LINSTOR Kubernetes CRs. Fields not stored in CRs are shown as "-".
+
+Examples:
+  linstor-viewer crs.gz node list
+  linstor-viewer crs.gz storage-pool list
+  linstor-viewer crs.gz volume list
+`)
+}

--- a/images/linstor-migrator/internal/linstorviewer/viewer_test.go
+++ b/images/linstor-migrator/internal/linstorviewer/viewer_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linstorviewer
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRunHelp(t *testing.T) {
+	if Run(nil) != 0 {
+		t.Fatal("expected exit 0 for no args")
+	}
+	if Run([]string{"--help"}) != 0 {
+		t.Fatal("expected exit 0 for --help")
+	}
+}
+
+func TestRunNodeList(t *testing.T) {
+	path := filepath.Join("testdata", "minimal-crs.yaml")
+	if code := Run([]string{path, "node", "list"}); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+}

--- a/images/linstor-migrator/internal/migrator/migrator.go
+++ b/images/linstor-migrator/internal/migrator/migrator.go
@@ -378,18 +378,17 @@ func (m *Migrator) runStage1(ctx context.Context) error {
 	return nil
 }
 
-// deleteLegacyReplicatedStoragePoolsForLinstorPoolNames deletes ReplicatedStoragePool objects whose metadata.name
-// equals a LINSTOR storage pool name seen during migration. Under the legacy control plane such pools were often
-// created with that exact name. Migrator-owned pools are named linstor-auto-* and RSC-controller pools are auto-rsp-*;
-// those prefixes are skipped so only legacy/manual objects are removed.
+// deleteLegacyReplicatedStoragePoolsForLinstorPoolNames backs up then deletes ReplicatedStoragePool objects whose
+// metadata.name equals a LINSTOR storage pool name seen during migration. Under the legacy control plane such pools
+// were often created with that exact name. Migrator-owned pools are named linstor-auto-* and RSC-controller pools are
+// auto-rsp-*; those prefixes are skipped so only legacy/manual objects are removed.
 func (m *Migrator) deleteLegacyReplicatedStoragePoolsForLinstorPoolNames(ctx context.Context, linstorPoolNames []string) error {
-	for _, poolName := range linstorPoolNames {
-		if poolName == "" {
-			continue
-		}
-		if strings.HasPrefix(poolName, config.AutoReplicatedStoragePoolNamePrefix) || strings.HasPrefix(poolName, config.AutoReplicatedStoragePoolRSCNamePrefix) {
-			continue
-		}
+	toDelete, err := linstorbackup.WriteLegacyRSPBackup(ctx, m.client, m.log, linstorbackup.BackupDir(), linstorPoolNames)
+	if err != nil {
+		return fmt.Errorf("backup legacy ReplicatedStoragePool objects: %w", err)
+	}
+
+	for _, poolName := range toDelete {
 		rsp := &srvv1alpha1.ReplicatedStoragePool{
 			ObjectMeta: metav1.ObjectMeta{Name: poolName},
 		}

--- a/images/linstor-migrator/werf.inc.yaml
+++ b/images/linstor-migrator/werf.inc.yaml
@@ -37,8 +37,10 @@ mount:
 
 shell:
   setup:
-    - cd /src/images/{{ $.ImageName }}/cmd
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /{{ $.ImageName }}
+    - cd /src/images/{{ $.ImageName }}
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /tmp/linstor-viewer ./cmd/linstor-viewer
+    - install -Dm 0755 /tmp/linstor-viewer ./internal/linstorbackup/embedded/linstor-viewer
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /{{ $.ImageName }} ./cmd
     - chmod +x /{{ $.ImageName }}
 
 ---


### PR DESCRIPTION
## Description
Two improvements to the linstor-migrator backup strategy:
1. **`linstor-viewer`** — a read-only CLI binary embedded into the migrator image via `go:embed`. After stage 1, it is installed into the backup directory alongside `crds.gz`/`crs.gz` and can reconstruct LINSTOR-style table listings (`node list`, `storage-pool list`, `volume list`) without a live LINSTOR controller. Fields not stored in CR backups are shown as `-`.
2. **Legacy RSP backup** — before deleting legacy `ReplicatedStoragePool` objects (those whose name matches a LINSTOR pool name, excluding `linstor-auto-*` and `auto-rsp-*`), they are now written to `legacy-rsp.gz` in the backup directory. The file is only created when such pools exist. The YAML is stripped of status/metadata for `kubectl apply` compatibility.
## Why do we need it, and what problem does it solve?
When migrating from the old LINSTOR-based control plane to the new ReplicatedVolume controller, the LINSTOR cluster is destroyed as part of stage 1. Operators currently have no easy way to verify the LINSTOR state that was backed up, and legacy `ReplicatedStoragePool` objects that matched LINSTOR pool names were deleted without any backup.
- `linstor-viewer` gives operators an offline read-only view of the LINSTOR cluster snapshot.
- `legacy-rsp.gz` preserves the definition of manually created RSPs.
## What is the expected result?
- After stage 1 completes, the backup directory (`linstor-backup-db`) contains `linstor-viewer` (executable binary) and optionally `legacy-rsp.gz`.
- `./linstor-viewer crs.gz node list` prints a table of LINSTOR nodes reconstructed from CR data.
- `./linstor-viewer crs.gz storage-pool list` and `volume list` work similarly.
- If legacy RSPs existed before migration, `legacy-rsp.gz` contains their definitions (without status); otherwise the file is absent.
- E2E tests verify the viewer binary is present, executable, and produces non-empty output for all three listing commands.
## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.