### PR TITLE
[agent] Fix reconcile goroutine leaks on stuck exec

### DIFF
--- a/e2e/agent/TESTCASES.md
+++ b/e2e/agent/TESTCASES.md
@@ -71,6 +71,22 @@ TestDRBDResource
 │       Verifies the agent handles orphan DRBD resources left behind
 │       when the K8S object disappears without the normal finalizer flow.
 │
+├── DStateRecovery — agent stays responsive when a child process hangs in D-state
+│       Creates a diskful DRBDResource ("frozen") with an LLV on node 0.
+│       Runs `dmsetup suspend` on the LLV's backing device path via
+│       NodeExec, which makes every subsequent drbd I/O against that LV
+│       (drbdmeta dump-md in the observe loop, drbdsetup attach on
+│       retry) block in uninterruptible kernel D-state. Then creates a
+│       second diskful DRBDResource ("canary") on the same node and
+│       asserts it reaches Configured=True within the normal timeout —
+│       proving the agent's reconcile worker pool is not exhausted by
+│       the wedged reconciles. Cleanup `dmsetup resume`s the LV so the
+│       parent scope's frozen-DRBDR cleanup can tear it down. Verifies
+│       the ctrlexec.WithCache + WithTimeout + WithWaitDelay wrapping
+│       installed in drbdr.BuildController bounds each reconcile attempt
+│       to ~drbdExecTimeout + drbdExecWaitDelay instead of blocking
+│       forever.
+│
 ├── NonManagedResource — non-managed DRBD resource left untouched
 │       Creates a DRBD resource directly on the node (via drbdsetup
 │       new-resource) without the sdsrv- prefix. Waits for the scanner
@@ -209,6 +225,13 @@ Every subtest's cleanup exercises a teardown path:
   finalizer flow), then re-creates it. Verifies the agent tears down the
   orphan DRBD resource on the node and brings the re-created object up
   cleanly. Cleanup deletes the re-created DRBDResource normally.
+
+- **DStateRecovery cleanup** (LIFO): canary's DisklessToDiskfulReplica
+  cleanup tears down the canary first (its LV was never suspended).
+  Then the helper's own cleanup runs `dmsetup resume` on the frozen LV
+  so the parent scope's frozen-DRBDR cleanup can teardown normally
+  afterward. Any accumulated D-state processes inside the agent pod
+  unblock as soon as the device resumes.
 
 - **NonManagedResource**: creates a non-prefixed DRBD resource directly
   on the node and verifies it survives after the scanner processes events.

--- a/e2e/agent/internal/suite/setup_d_state_recovery.go
+++ b/e2e/agent/internal/suite/setup_d_state_recovery.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package suite
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
+	"github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+	"github.com/deckhouse/sds-replicated-volume/e2e/agent/pkg/envtesting"
+	"github.com/deckhouse/sds-replicated-volume/e2e/agent/pkg/kubetesting"
+)
+
+// SetupDStateRecovery freezes I/O to the backing LV of a pre-existing diskful
+// DRBDResource using `dmsetup suspend`, then verifies that the agent's
+// reconcile worker pool is not exhausted by the wedged reconciles: a second
+// (canary) DRBDResource on the same node must still reach Configured=True
+// within the normal timeout.
+//
+// While the LV is suspended, every drbd I/O against it (drbdmeta dump-md
+// during the observe loop, drbdsetup attach if re-tried, etc.) blocks in
+// uninterruptible kernel D-state. Without ctrlexec.WithCache + WithTimeout +
+// WithWaitDelay wrapping the production exec factory in
+// drbdr.BuildController, those reconciles would block their worker
+// goroutines indefinitely; with the wrappers, each attempt returns within
+// ~drbdExecTimeout + drbdExecWaitDelay and the worker is freed.
+//
+// Cleanup `dmsetup resume`s the LV so the parent scope's cleanup
+// (SetupDisklessToDiskfulReplica for the frozen resource) can tear it down.
+// The resume runs before the canary's cleanups (LIFO ordering).
+//
+// Requirements (caller's responsibility):
+//   - cluster.Nodes[nodeIdx]'s LVG MUST have at least 2x AllocateSize free,
+//     because both the frozen LV and the canary LV are allocated against it.
+//   - The agent pod on cluster.Nodes[nodeIdx] MUST have `dmsetup` available
+//     and permission to suspend a device on the host.
+func SetupDStateRecovery(
+	e envtesting.E,
+	cl client.WithWatch,
+	cluster *Cluster,
+	ne *kubetesting.NodeExec,
+	drbdrFrozen *v1alpha1.DRBDResource,
+	llvFrozen *snc.LVMLogicalVolume,
+	canaryPrefix string,
+	nodeIdx int,
+) {
+	if drbdrFrozen == nil {
+		e.Fatal("require: drbdrFrozen must not be nil")
+	}
+	if llvFrozen == nil {
+		e.Fatal("require: llvFrozen must not be nil")
+	}
+
+	node := cluster.Nodes[nodeIdx]
+
+	// `dmsetup` accepts a device path; using the LVM symlink is robust
+	// against dm-mapper name mangling (LVM doubles dashes in mapper names).
+	devPath := fmt.Sprintf("/dev/%s/%s",
+		node.LVG.Spec.ActualVGNameOnTheNode,
+		llvFrozen.Spec.ActualLVNameOnTheNode)
+
+	// Arrange: freeze I/O to the backing LV. After this, any drbd-side read
+	// or write against drbdrFrozen's backing device blocks in D-state.
+	ne.Exec(e, node.Name, "dmsetup", "suspend", devPath)
+	resumed := false
+	e.Cleanup(func() {
+		if !resumed {
+			ne.Exec(e, node.Name, "dmsetup", "resume", devPath)
+		}
+	})
+
+	// Act + Assert: create a canary diskful DRBDResource on the same node.
+	// Its LV is freshly allocated from the same VG, independent of the
+	// suspended one, so it must reach Configured=True within the configured
+	// timeout. Failure to do so means the agent's reconcile worker pool is
+	// blocked by the wedged reconciles of drbdrFrozen — i.e. the D-state
+	// protection (ctrlexec.WithCache + WithTimeout) is not in place or is
+	// not effective.
+	SetupDisklessToDiskfulReplica(e, cl, cluster, canaryPrefix, nodeIdx)
+
+	// Resume the LV so the parent scope's frozen-DRBDR cleanup can tear it
+	// down cleanly. Any accumulated D-state processes inside the agent pod
+	// unblock as soon as the device resumes.
+	ne.Exec(e, node.Name, "dmsetup", "resume", devPath)
+	resumed = true
+}

--- a/e2e/agent/main_test.go
+++ b/e2e/agent/main_test.go
@@ -89,6 +89,11 @@ func TestDRBDResource(t *testing.T) {
 		suite.SetupOrphanCleanup(e, cl, cluster, "oc", 0)
 	})
 
+	e.Run("DStateRecovery", func(e envtesting.E) {
+		drbdrFrozen, llvFrozen := suite.SetupDisklessToDiskfulReplica(e, cl, cluster, "ds", 0)
+		suite.SetupDStateRecovery(e, cl, cluster, nodeExec, drbdrFrozen, llvFrozen, "dsc", 0)
+	})
+
 	ne := kubetesting.DiscoverNodeExec(e, cs, podLogOpts)
 
 	e.Run("NonManagedResource", func(e envtesting.E) {

--- a/images/agent/cmd/main.go
+++ b/images/agent/cmd/main.go
@@ -62,7 +62,15 @@ func main() {
 const drbdUsermodeHelperPath = "/sys/module/drbd/parameters/usermode_helper"
 
 func disableDRBDUsermodeHelper(log *slog.Logger) {
-	if err := os.WriteFile(drbdUsermodeHelperPath, []byte("disabled\n"), 0o644); err != nil {
+	// MUST be exactly "disabled" without a trailing newline: DRBD's
+	// drbd_maybe_khelper short-circuits on strcmp(drbd_usermode_helper,
+	// "disabled") == 0 (see 3p-drbd drbd/drbd_nl.c). The kernel's
+	// param_set_copystring is a raw strcpy and preserves whatever we
+	// write, so a trailing '\n' breaks the equality test, the
+	// short-circuit doesn't fire, every helper invocation reaches
+	// call_usermodehelper("disabled\n", ...), fails with -ENOENT, and
+	// the kernel logs a KERN_WARNING per invocation.
+	if err := os.WriteFile(drbdUsermodeHelperPath, []byte("disabled"), 0o644); err != nil {
 		log.Warn("failed to disable DRBD usermode helper", "path", drbdUsermodeHelperPath, "err", err)
 	} else {
 		log.Info("disabled DRBD usermode helper", "path", drbdUsermodeHelperPath)

--- a/images/agent/internal/controllers/drbdm/controller.go
+++ b/images/agent/internal/controllers/drbdm/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/env"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/indexes"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/pkg/dmsetup"
+	"github.com/deckhouse/sds-replicated-volume/lib/go/common/ctrlexec"
 )
 
 // BuildController creates and registers the DRBD mapper controller and scanner with the manager.
@@ -50,11 +51,13 @@ func BuildController(mgr manager.Manager) error {
 	cl := mgr.GetClient()
 	nodeName := cfg.NodeName()
 
-	origExec := dmsetup.ExecCommandContext
-	dmsetup.ExecCommandContext = func(ctx context.Context, name string, arg ...string) dmsetup.Cmd {
-		log.FromContext(ctx).Info("executing command", "command", name, "args", arg)
-		return origExec(ctx, name, arg...)
-	}
+	// dmsetup can block on backing-device I/O; bare exec would leak the
+	// reconcile goroutine. See drbdr.BuildController for the rationale
+	// behind this wrapper composition.
+	dmsetup.ExecCommandContext = withDMSetupCommandLogging(
+		ctrlexec.WithCache(
+			ctrlexec.WithTimeout(dmsetup.ExecTimeout,
+				ctrlexec.ExecCommandContext(dmsetup.ConfigureCmd))))
 
 	requestCh := make(chan event.TypedGenericEvent[reconcile.Request], 100)
 
@@ -84,4 +87,13 @@ func BuildController(mgr manager.Manager) error {
 	}
 
 	return nil
+}
+
+// withDMSetupCommandLogging wraps a factory so every dmsetup command
+// invocation is logged at info level on the per-call context's logger.
+func withDMSetupCommandLogging(factory ctrlexec.ExecCommandContextFactory) ctrlexec.ExecCommandContextFactory {
+	return func(ctx context.Context, name string, args ...string) ctrlexec.Cmd {
+		log.FromContext(ctx).Info("executing command", "command", name, "args", args)
+		return factory(ctx, name, args...)
+	}
 }

--- a/images/agent/internal/controllers/drbdr/controller.go
+++ b/images/agent/internal/controllers/drbdr/controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/env"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/internal/indexes"
 	"github.com/deckhouse/sds-replicated-volume/images/agent/pkg/drbdutils"
+	"github.com/deckhouse/sds-replicated-volume/lib/go/common/ctrlexec"
 )
 
 // BuildController creates and registers the DRBD controller and scanner with the manager.
@@ -60,12 +61,24 @@ func BuildController(mgr manager.Manager) error {
 	cl := mgr.GetClient()
 	nodeName := cfg.NodeName()
 
-	// Set up drbd command logging
-	origExec := drbdutils.ExecCommandContext
-	drbdutils.ExecCommandContext = func(ctx context.Context, name string, arg ...string) drbdutils.Cmd {
-		log.FromContext(ctx).Info("executing drbd command", "command", name, "args", arg)
-		return origExec(ctx, name, arg...)
-	}
+	// drbdsetup/drbdmeta can hang indefinitely on backing-device I/O
+	// (most commonly when an LV underneath enters uninterruptible
+	// D-state); bare exec would leak the reconcile goroutine forever.
+	// The one-shot factory wraps each call so the reconcile context
+	// stays cancellable (WithCache), the underlying process is bounded
+	// (WithTimeout), and Cmd.Wait survives pipe-holding grandchildren
+	// (ConfigureCmd sets WaitDelay).
+	//
+	// events2 streams via StdoutPipe+Start+Wait and runs for the
+	// manager lifetime — neither WithCache (CombinedOutput-only) nor a
+	// per-call timeout fits — so it uses a bare factory and relies on
+	// ConfigureCmd alone for pipe-orphan safety.
+	drbdutils.ExecCommandContext = withDRBDCommandLogging(
+		ctrlexec.WithCache(
+			ctrlexec.WithTimeout(drbdutils.ExecTimeout,
+				ctrlexec.ExecCommandContext(drbdutils.ConfigureCmd))))
+	drbdutils.Events2ExecCommandContext = withDRBDCommandLogging(
+		ctrlexec.ExecCommandContext(drbdutils.ConfigureCmd))
 
 	// Create internal request channel (scanner sends here)
 	requestCh := make(chan event.TypedGenericEvent[DRBDReconcileRequest], 100)
@@ -128,6 +141,15 @@ func BuildController(mgr manager.Manager) error {
 	}
 
 	return nil
+}
+
+// withDRBDCommandLogging wraps a factory so every drbd command invocation
+// is logged at info level on the per-call context's logger.
+func withDRBDCommandLogging(factory ctrlexec.ExecCommandContextFactory) ctrlexec.ExecCommandContextFactory {
+	return func(ctx context.Context, name string, args ...string) ctrlexec.Cmd {
+		log.FromContext(ctx).Info("executing drbd command", "command", name, "args", args)
+		return factory(ctx, name, args...)
+	}
 }
 
 func withDurationLogging(inner reconcile.TypedReconciler[DRBDReconcileRequest]) reconcile.TypedReconciler[DRBDReconcileRequest] {

--- a/images/agent/pkg/dmsetup/cmd.go
+++ b/images/agent/pkg/dmsetup/cmd.go
@@ -17,35 +17,40 @@ limitations under the License.
 package dmsetup
 
 import (
-	"context"
 	"fmt"
 	"os/exec"
+	"time"
+
+	"github.com/deckhouse/sds-replicated-volume/lib/go/common/ctrlexec"
 )
 
 const dmsetupCommand = "dmsetup"
 
-// Cmd abstracts command execution for testing.
-type Cmd interface {
-	CombinedOutput() ([]byte, error)
+const (
+	// ExecTimeout is the production per-invocation timeout. dmsetup
+	// info/create/remove are normally sub-second; this value is the
+	// worst-case bound for a kernel-side stall (e.g. backing block
+	// device in D-state).
+	ExecTimeout = 10 * time.Second
+
+	// ExecWaitDelay is the production WaitDelay applied by ConfigureCmd.
+	// dmsetup speaks to the device-mapper ioctl interface and can leave
+	// helpers behind on error paths, so a nonzero value is required to
+	// keep Cmd.Wait from blocking forever on orphaned pipes.
+	ExecWaitDelay = 3 * time.Second
+)
+
+// ConfigureCmd applies the production *exec.Cmd policy for dmsetup
+// invocations. Pass it as the configure argument to
+// ctrlexec.ExecCommandContext when wiring a factory.
+func ConfigureCmd(c *exec.Cmd) {
+	c.WaitDelay = ExecWaitDelay
 }
 
-// ExecCommandContextFactory creates a Cmd for the given command and arguments.
-type ExecCommandContextFactory func(ctx context.Context, name string, arg ...string) Cmd
-
-// ExecCommandContext is overridable for testing purposes.
-var ExecCommandContext ExecCommandContextFactory = func(
-	ctx context.Context,
-	name string,
-	arg ...string,
-) Cmd {
-	return (*execCmd)(exec.CommandContext(ctx, name, arg...))
-}
-
-type execCmd exec.Cmd
-
-var _ Cmd = &execCmd{}
-
-func (r *execCmd) CombinedOutput() ([]byte, error) { return (*exec.Cmd)(r).CombinedOutput() }
+// ExecCommandContext is overridable for testing and for installing a
+// wrapped factory at controller startup. The package default applies no
+// policy; production code MUST override it (see ConfigureCmd, ExecTimeout).
+var ExecCommandContext ctrlexec.ExecCommandContextFactory = ctrlexec.ExecCommandContext(nil)
 
 func withOutput(err error, out []byte) error {
 	if len(out) == 0 {

--- a/images/agent/pkg/drbdutils/command.go
+++ b/images/agent/pkg/drbdutils/command.go
@@ -17,36 +17,49 @@ limitations under the License.
 package drbdutils
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/deckhouse/sds-replicated-volume/lib/go/common/ctrlexec"
 )
 
-// CombinedOutputRunner is the minimal interface needed by executeCommand.
-type CombinedOutputRunner interface {
-	CombinedOutput() ([]byte, error)
-	String() string
+const (
+	// ExecTimeout is the production per-invocation timeout for one-shot
+	// drbdsetup/drbdmeta commands. Sized for happy-path metadata
+	// operations (create-md, attach, resize, write-dev-uuid) on typical
+	// volumes while still being small enough to cap goroutine pile-up
+	// when a command gets stuck behind a kernel-side stall.
+	ExecTimeout = 10 * time.Second
+
+	// ExecWaitDelay is the production WaitDelay applied by ConfigureCmd.
+	// drbdsetup and drbdmeta wrap kernel ioctls and can leave helpers
+	// behind on error paths, so a nonzero value is required to keep
+	// Cmd.Wait from blocking forever on orphaned pipes.
+	ExecWaitDelay = 3 * time.Second
+)
+
+// ConfigureCmd applies the production *exec.Cmd policy for
+// drbdsetup/drbdmeta invocations. Pass it as the configure argument to
+// ctrlexec.ExecCommandContext when wiring a factory.
+func ConfigureCmd(c *exec.Cmd) {
+	c.WaitDelay = ExecWaitDelay
 }
 
-// Cmd is the full command interface used for both one-shot and streaming
-// (e.g. events2) command execution.
-type Cmd interface {
-	CombinedOutputRunner
-	StdoutPipe() (io.ReadCloser, error)
-	Start() error
-	Wait() error
-}
+// ExecCommandContext is the factory used by every one-shot Execute*
+// helper (status, attach, options, peer mgmt, etc.). It is overridable at
+// controller startup; the package default applies no policy, so
+// production code MUST override it (see ConfigureCmd, ExecTimeout).
+var ExecCommandContext ctrlexec.ExecCommandContextFactory = ctrlexec.ExecCommandContext(nil)
 
-type ExecCommandContextFactory func(ctx context.Context, name string, arg ...string) Cmd
-
-func defaultExecCommandContext(ctx context.Context, name string, arg ...string) Cmd {
-	return exec.CommandContext(ctx, name, arg...)
-}
-
-var ExecCommandContext ExecCommandContextFactory = defaultExecCommandContext
+// Events2ExecCommandContext is the factory used exclusively by
+// ExecuteEvents2. It is a separate variable because events2 streams via
+// StdoutPipe+Start+Wait — incompatible with ctrlexec.WithCache's
+// CombinedOutput path — and is expected to run for the entire manager
+// lifetime, ruling out a per-call timeout.
+var Events2ExecCommandContext ctrlexec.ExecCommandContextFactory = ctrlexec.ExecCommandContext(nil)
 
 var DRBDSetupCommand = "drbdsetup"
 
@@ -76,7 +89,7 @@ func withOutput(err error, out []byte) error {
 }
 
 func executeCommand(
-	cmd CombinedOutputRunner,
+	cmd ctrlexec.CombinedOutputRunner,
 	knownErrors []KnownError,
 ) ([]byte, error) {
 	out, err := cmd.CombinedOutput()

--- a/images/agent/pkg/drbdutils/events2.go
+++ b/images/agent/pkg/drbdutils/events2.go
@@ -73,7 +73,7 @@ func ExecuteEvents2(
 	}
 
 	return func(yield func(Events2Result) bool) {
-		cmd := ExecCommandContext(
+		cmd := Events2ExecCommandContext(
 			ctx,
 			DRBDSetupCommand,
 			Events2Args...,

--- a/images/agent/pkg/drbdutils/fake/fake.go
+++ b/images/agent/pkg/drbdutils/fake/fake.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/deckhouse/sds-replicated-volume/images/agent/pkg/drbdutils"
+	"github.com/deckhouse/sds-replicated-volume/lib/go/common/ctrlexec"
 )
 
 type Exec struct {
@@ -38,11 +39,17 @@ func (b *Exec) ExpectCommands(cmds ...*ExpectedCmd) {
 func (b *Exec) Setup(t *testing.T) {
 	t.Helper()
 
-	tmp := drbdutils.ExecCommandContext
+	tmpExec := drbdutils.ExecCommandContext
+	tmpEvents2 := drbdutils.Events2ExecCommandContext
 
 	i := 0
 
-	drbdutils.ExecCommandContext = func(_ context.Context, name string, args ...string) drbdutils.Cmd {
+	// Both factories route through the same expectation queue so tests can
+	// assert command order across Execute* + ExecuteEvents2 calls. Production
+	// wiring composes wrappers (cache/timeout/WaitDelay) differently for
+	// each factory, but the test fake is concerned only with what command
+	// names and arguments were invoked.
+	shared := func(_ context.Context, name string, args ...string) ctrlexec.Cmd {
 		if len(b.cmds) <= i {
 			t.Fatalf("expected %d command executions, got more", len(b.cmds))
 		}
@@ -56,11 +63,13 @@ func (b *Exec) Setup(t *testing.T) {
 		return cmd
 	}
 
-	t.Cleanup(func() {
-		// actual cleanup
-		drbdutils.ExecCommandContext = tmp
+	drbdutils.ExecCommandContext = shared
+	drbdutils.Events2ExecCommandContext = shared
 
-		// assert all commands executed
+	t.Cleanup(func() {
+		drbdutils.ExecCommandContext = tmpExec
+		drbdutils.Events2ExecCommandContext = tmpEvents2
+
 		if i != len(b.cmds) {
 			t.Errorf("expected %d command executions, got %d", len(b.cmds), i)
 		}
@@ -78,7 +87,7 @@ type ExpectedCmd struct {
 	stdoutReader io.ReadCloser
 }
 
-var _ drbdutils.Cmd = &ExpectedCmd{}
+var _ ctrlexec.Cmd = &ExpectedCmd{}
 
 func (c *ExpectedCmd) Matches(name string, args ...string) bool {
 	return c.Name == name && slices.Equal(c.Args, args)

--- a/lib/go/common/ctrlexec/cache.go
+++ b/lib/go/common/ctrlexec/cache.go
@@ -1,0 +1,143 @@
+package ctrlexec
+
+import (
+	"context"
+	"hash/maphash"
+	"io"
+	"sync"
+)
+
+var seed = maphash.MakeSeed()
+
+var (
+	runningMu       sync.Mutex
+	runningCommands = map[uint64]*cacheEntry{}
+)
+
+type cacheEntry struct {
+	done   chan struct{}
+	output []byte
+	err    error
+}
+
+// WithCache wraps target with a process-wide deduplicating cache for in-flight
+// command executions.
+//
+// When the returned factory is invoked, the resulting Cmd executes the target
+// Cmd in a background goroutine on the first call to Start or CombinedOutput.
+// The target is built with a context detached from the caller's, so the
+// underlying process is not killed when the caller's context expires; the
+// caller's context only governs *waiting* for the result.
+//
+// Concurrent invocations sharing the same (name, args...) tuple are
+// deduplicated: only one underlying process runs and all callers wait on its
+// result. The cache entry is removed once the process completes.
+//
+// This is intended for command-line tools that may block in uninterruptible
+// kernel state (D-state). A Kubernetes controller can return from Reconcile
+// when its context expires without leaking a goroutine blocked on the stuck
+// process; a subsequent reconcile attaches to the still-running command
+// rather than spawning a duplicate.
+func WithCache(target ExecCommandContextFactory) ExecCommandContextFactory {
+	return func(ctx context.Context, name string, args ...string) Cmd {
+		var h maphash.Hash
+		h.SetSeed(seed)
+
+		h.WriteString(name)
+		h.WriteByte(0)
+
+		for _, arg := range args {
+			h.WriteString(arg)
+			h.WriteByte(0)
+		}
+
+		// Detach from caller ctx: caller cancellation must not kill the
+		// running process. A later reconcile attaches to it instead.
+		return &cachedCmd{
+			ctx:    ctx,
+			target: target(context.WithoutCancel(ctx), name, args...),
+			key:    h.Sum64(),
+		}
+	}
+}
+
+type cachedCmd struct {
+	ctx    context.Context
+	target Cmd
+	key    uint64
+
+	once  sync.Once
+	entry *cacheEntry
+}
+
+var _ Cmd = (*cachedCmd)(nil)
+
+func (c *cachedCmd) String() string {
+	return c.target.String()
+}
+
+func (c *cachedCmd) StdoutPipe() (io.ReadCloser, error) {
+	return c.target.StdoutPipe()
+}
+
+// ensureStarted attaches to (or creates) the shared cache entry and ensures
+// the target Cmd is running in a background goroutine. It is safe to call
+// multiple times; only the first call has an effect on this instance.
+func (c *cachedCmd) ensureStarted() *cacheEntry {
+	c.once.Do(func() {
+		runningMu.Lock()
+		if existing, ok := runningCommands[c.key]; ok {
+			c.entry = existing
+			runningMu.Unlock()
+			return
+		}
+
+		e := &cacheEntry{done: make(chan struct{})}
+		runningCommands[c.key] = e
+		runningMu.Unlock()
+
+		c.entry = e
+
+		go func() {
+			output, err := c.target.CombinedOutput()
+
+			// The writes below are safe without a lock: e.output and e.err are
+			// only read after <-e.done returns, and close(e.done) provides the
+			// happens-before edge.
+			e.output = output
+			e.err = err
+
+			runningMu.Lock()
+			delete(runningCommands, c.key)
+			runningMu.Unlock()
+
+			close(e.done)
+		}()
+	})
+	return c.entry
+}
+
+func (c *cachedCmd) CombinedOutput() ([]byte, error) {
+	e := c.ensureStarted()
+	select {
+	case <-e.done:
+		return e.output, e.err
+	case <-c.ctx.Done():
+		return nil, c.ctx.Err()
+	}
+}
+
+func (c *cachedCmd) Start() error {
+	c.ensureStarted()
+	return nil
+}
+
+func (c *cachedCmd) Wait() error {
+	e := c.ensureStarted()
+	select {
+	case <-e.done:
+		return e.err
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	}
+}

--- a/lib/go/common/ctrlexec/cache_test.go
+++ b/lib/go/common/ctrlexec/cache_test.go
@@ -1,0 +1,162 @@
+package ctrlexec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWithCache_BasicEcho verifies a trivial command runs and returns its output.
+func TestWithCache_BasicEcho(t *testing.T) {
+	factory := WithCache(ExecCommandContext(nil))
+
+	cmd := factory(context.Background(), "echo", uniqueArg(t), "hello")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("CombinedOutput: %v", err)
+	}
+	if got := string(out); !strings.HasSuffix(got, "hello\n") {
+		t.Fatalf("output = %q, want suffix %q", got, "hello\n")
+	}
+}
+
+// TestWithCache_DeduplicatesConcurrentCalls runs N concurrent invocations of
+// the same command and verifies that only one underlying process actually
+// ran, by counting PIDs appended to a marker file.
+func TestWithCache_DeduplicatesConcurrentCalls(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "marker")
+	factory := WithCache(ExecCommandContext(nil))
+
+	// $$ is the PID of this sh; sleep 1 keeps the process alive long enough
+	// that all goroutines attach to the cached entry before it completes.
+	script := fmt.Sprintf(`echo $$ >> %q; sleep 1`, marker)
+
+	const N = 5
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for range N {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			cmd := factory(context.Background(), "sh", "-c", script)
+			if _, err := cmd.CombinedOutput(); err != nil {
+				t.Errorf("CombinedOutput: %v", err)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 underlying execution, marker contents (%d lines):\n%s", len(lines), data)
+	}
+}
+
+// TestWithCache_ContextTimeoutDoesNotKillProcess verifies that when the
+// caller's context expires while the command is still running, CombinedOutput
+// returns context.DeadlineExceeded but the underlying process keeps running
+// to completion.
+func TestWithCache_ContextTimeoutDoesNotKillProcess(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "marker")
+	factory := WithCache(ExecCommandContext(nil))
+
+	script := fmt.Sprintf(`sleep 0.5; echo done > %q`, marker)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	cmd := factory(ctx, "sh", "-c", script)
+	_, err := cmd.CombinedOutput()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("marker should not exist yet (process should still be running): err=%v", statErr)
+	}
+
+	// Poll for the marker; the background goroutine should complete despite
+	// the caller's context having been cancelled.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, statErr := os.Stat(marker); statErr == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("background goroutine did not complete and write marker")
+}
+
+// TestWithCache_AttachToStillRunning verifies that when a first call's context
+// times out while the underlying command is still running, a second call with
+// a fresh context attaches to the same goroutine instead of spawning a fresh
+// process. We observe this by counting PIDs appended to a marker file.
+func TestWithCache_AttachToStillRunning(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "marker")
+	factory := WithCache(ExecCommandContext(nil))
+
+	script := fmt.Sprintf(`echo $$ >> %q; sleep 1; printf done`, marker)
+	mkCmd := func(ctx context.Context) Cmd {
+		return factory(ctx, "sh", "-c", script)
+	}
+
+	// First call: ctx times out long before the 1s sleep completes.
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel1()
+	if _, err := mkCmd(ctx1).CombinedOutput(); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first call: expected DeadlineExceeded, got %v", err)
+	}
+
+	// Second call: must attach to the still-running goroutine.
+	out, err := mkCmd(context.Background()).CombinedOutput()
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if string(out) != "done" {
+		t.Fatalf("second call output = %q, want %q", out, "done")
+	}
+
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 underlying execution, marker contents (%d lines):\n%s", len(lines), data)
+	}
+}
+
+// TestWithCache_StartWait verifies that Start/Wait round-trips successfully.
+func TestWithCache_StartWait(t *testing.T) {
+	factory := WithCache(ExecCommandContext(nil))
+
+	cmd := factory(context.Background(), "sh", "-c", "exit 0", "--", uniqueArg(t))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+// uniqueArg returns a marker string that makes a command's cache key unique
+// to a given test, avoiding cross-test collisions on the global cache.
+func uniqueArg(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("ctrlexec-test-%s-%d", t.Name(), time.Now().UnixNano())
+}

--- a/lib/go/common/ctrlexec/cmd.go
+++ b/lib/go/common/ctrlexec/cmd.go
@@ -1,0 +1,86 @@
+package ctrlexec
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// CombinedOutputRunner is the minimal interface needed by executeCommand.
+type CombinedOutputRunner interface {
+	CombinedOutput() ([]byte, error)
+	String() string
+}
+
+// Cmd is the full command interface used for both one-shot and streaming
+// (e.g. events2) command execution.
+type Cmd interface {
+	CombinedOutputRunner
+	StdoutPipe() (io.ReadCloser, error)
+	Start() error
+	Wait() error
+}
+
+type ExecCommandContextFactory func(ctx context.Context, name string, args ...string) Cmd
+
+// ExecCommandContext returns an ExecCommandContextFactory backed by
+// exec.CommandContext. If configure is non-nil, it is invoked on each
+// freshly constructed *exec.Cmd before the Cmd is returned, giving the
+// caller a chance to set fields such as WaitDelay, Dir, Env, Stderr, or
+// SysProcAttr.
+//
+// configure runs synchronously inside the factory and MUST NOT block; it
+// is called for every invocation of the returned factory.
+//
+// Setting WaitDelay > 0 here is strongly recommended for any command-line
+// tool that may have grandchildren inheriting stdout/stderr pipes (most
+// shell-invoked utilities qualify), because WaitDelay bounds Cmd.Wait()'s
+// patience for those pipes to close after the process exits. Without it,
+// Cmd.Wait() can block until the grandchild itself dies, which may be
+// never.
+func ExecCommandContext(configure func(*exec.Cmd)) ExecCommandContextFactory {
+	return func(ctx context.Context, name string, args ...string) Cmd {
+		c := exec.CommandContext(ctx, name, args...)
+		if configure != nil {
+			configure(c)
+		}
+		return c
+	}
+}
+
+// WithTimeout returns a factory that bounds the lifetime of each command's
+// context to timeout. The resulting Cmd cancels that context after
+// CombinedOutput or Wait returns, releasing the timer goroutine.
+func WithTimeout(timeout time.Duration, target ExecCommandContextFactory) ExecCommandContextFactory {
+	return func(ctx context.Context, name string, args ...string) Cmd {
+		tctx, cancel := context.WithTimeout(ctx, timeout)
+		return &timeoutCmd{
+			Cmd:    target(tctx, name, args...),
+			cancel: cancel,
+		}
+	}
+}
+
+// timeoutCmd wraps a Cmd to invoke cancel exactly once, when CombinedOutput
+// or Wait returns. If the caller calls Start without ever calling Wait, the
+// context will be released when its own timeout fires; nothing leaks
+// permanently.
+type timeoutCmd struct {
+	Cmd
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (c *timeoutCmd) cleanup() { c.once.Do(c.cancel) }
+
+func (c *timeoutCmd) CombinedOutput() ([]byte, error) {
+	defer c.cleanup()
+	return c.Cmd.CombinedOutput()
+}
+
+func (c *timeoutCmd) Wait() error {
+	defer c.cleanup()
+	return c.Cmd.Wait()
+}

--- a/lib/go/common/ctrlexec/cmd_test.go
+++ b/lib/go/common/ctrlexec/cmd_test.go
@@ -1,0 +1,118 @@
+package ctrlexec
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withWaitDelay is a small test helper that builds a configure func for
+// ExecCommandContext setting only WaitDelay.
+func withWaitDelay(d time.Duration) func(*exec.Cmd) {
+	return func(c *exec.Cmd) { c.WaitDelay = d }
+}
+
+// TestWithTimeout_DoesNotKillImmediately verifies that WithTimeout does NOT
+// cancel the context as soon as the factory returns. A bare `echo` should
+// complete successfully under a 10s timeout — the previous `defer cancel()`
+// bug would have killed the process on Start.
+func TestWithTimeout_DoesNotKillImmediately(t *testing.T) {
+	factory := WithTimeout(10*time.Second, ExecCommandContext(nil))
+
+	cmd := factory(context.Background(), "echo", uniqueArg(t), "hi")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("CombinedOutput: %v; out=%q", err, out)
+	}
+	if !strings.HasSuffix(string(out), "hi\n") {
+		t.Fatalf("output = %q, want suffix %q", out, "hi\n")
+	}
+}
+
+// TestWithTimeout_KillsAfterTimeout verifies that the wrapped context's
+// timeout does kill a long-running process.
+//
+// `sleep` is invoked directly (not through a shell) so killing the process
+// kills `sleep` itself with no orphaned-pipe hazard.
+func TestWithTimeout_KillsAfterTimeout(t *testing.T) {
+	factory := WithTimeout(100*time.Millisecond, ExecCommandContext(nil))
+
+	cmd := factory(context.Background(), "sleep", "30")
+	start := time.Now()
+	_, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected non-nil error from timed-out command, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("expected command to be killed within ~100ms+slack, took %s", elapsed)
+	}
+}
+
+// TestWithTimeout_ComposedWithCache verifies the recommended composition:
+// WithCache(WithTimeout(...)) bounds the underlying process even when the
+// caller's context is never cancelled. `sleep` is invoked directly to avoid
+// the shell-fork pipe-orphan scenario tested separately.
+func TestWithTimeout_ComposedWithCache(t *testing.T) {
+	factory := WithCache(WithTimeout(200*time.Millisecond, ExecCommandContext(nil)))
+
+	cmd := factory(context.Background(), "sleep", "30")
+	start := time.Now()
+	_, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("expected ~200ms+slack, took %s", elapsed)
+	}
+}
+
+// TestExecCommandContext_ConfigureSetsWaitDelay reproduces the
+// orphaned-pipe hang: the shell exits immediately but the backgrounded
+// `sleep 10` keeps the pipes open. With a configure func that sets
+// WaitDelay, CombinedOutput must return shortly after the shell exits
+// instead of waiting for the orphan to die.
+func TestExecCommandContext_ConfigureSetsWaitDelay(t *testing.T) {
+	factory := ExecCommandContext(withWaitDelay(200 * time.Millisecond))
+
+	cmd := factory(context.Background(), "sh", "-c", "sleep 10 & exit 0")
+	start := time.Now()
+	_, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("expected exec.ErrWaitDelay, got %v", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("expected ~200ms+slack, took %s", elapsed)
+	}
+}
+
+// TestExecCommandContext_ConfigureWaitDelayComposedWithCacheAndTimeout
+// verifies the full recommended composition exercises both fixes — pipe
+// orphan AND D-state safety paths line up. The shell exits immediately
+// (orphan path), so we hit the WaitDelay branch in awaitGoroutines, not
+// the WithTimeout kill path; total time should be ~WaitDelay.
+func TestExecCommandContext_ConfigureWaitDelayComposedWithCacheAndTimeout(t *testing.T) {
+	factory := WithCache(
+		WithTimeout(30*time.Second,
+			ExecCommandContext(withWaitDelay(200*time.Millisecond))))
+
+	cmd := factory(context.Background(), "sh", "-c", "sleep 10 & exit 0")
+	start := time.Now()
+	_, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("expected exec.ErrWaitDelay, got %v", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("expected ~200ms+slack, took %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Description

Bound every shell-out from the agent's reconcilers so a stuck child
process can no longer park a worker goroutine indefinitely.

What changes:

- New `lib/go/common/ctrlexec` package. Wraps `exec.CommandContext`
  with three composable layers:
  - `WithTimeout(d)`: caps each attempt.
  - `WithCache`: detaches the process from the caller's context and
    deduplicates concurrent invocations on `(name, args)`, so a
    Reconcile that returns on timeout releases its goroutine while
    the kernel call keeps running; the next Reconcile attaches to
    the in-flight process instead of spawning a duplicate.
  - `ConfigureCmd` (per-package): sets `WaitDelay` so `Cmd.Wait`
    cannot block forever on grandchildren that inherit the stdout
    pipe.
- `drbdr`/`drbdm` `BuildController` install
  `WithCache(WithTimeout(ConfigureCmd))` over `drbdutils.ExecCommand
  Context` and `dmsetup.ExecCommandContext`. `drbdsetup events2` is
  long-lived and incompatible with the cached/timed path, so
  `drbdutils` splits its factory in two and the events2 path uses
  bare `ConfigureCmd`.
- New `TestDRBDResource/DStateRecovery` e2e test wedges a backing LV
  with `dmsetup suspend` and asserts a sibling DRBDResource on the
  same node still reaches `Configured=True` within the normal
  timeout.
- Drop the trailing `\n` in the `"disabled"` write to
  `/sys/module/drbd/parameters/usermode_helper`. The newline broke
  `drbd_maybe_khelper`'s `strcmp == 0` short-circuit, so every peer
  disconnect fell through to `call_usermodehelper("disabled\n", ...)`
  and produced a `KERN_WARNING` per call — surfaced as `level=ERROR`
  by the kmsg forwarder (#673) and tripping the e2e log-error
  watcher with false-positive test failures.

## Why do we need it, and what problem does it solve?

A single wedged backing device on a node used to silently exhaust
the agent's reconcile worker pool: unrelated DRBDResources stopped
converging on that node and the only recovery was restarting the
pod. The wrappers contain the wedge to its own resource; healthy
peers keep reconciling.

The helper-command newline bug was harmless before #673 (warnings
went to dmesg only). After #673 they reach the agent's log at ERROR
level, generating dozens of false-positive failures per e2e run and
real noise for SREs.

## What is the expected result?

- A DRBDResource whose backing LV is `dmsetup suspend`-ed no longer
  prevents other DRBDResources on the same node from converging
  (covered by `TestDRBDResource/DStateRecovery`).
- `kubectl logs ds/agent -c agent | grep 'helper command'` → empty
  (was: 2 lines per peer disconnect).
- `drbdsetup events2` stream behavior unchanged.
- No CRD or API changes.

## Checklist
- [x] The code is covered by unit tests
      (`lib/go/common/ctrlexec/{cmd,cache}_test.go`).
- [x] e2e tests passed (`TestDRBDResource/DStateRecovery` plus full
      `e2e/agent` suite; 0 helper-command lines, 0 non-kernel errors).
- [x] Documentation updated according to the changes
      (`e2e/agent/TESTCASES.md`).
- [x] Changes were tested in the Kubernetes cluster manually.