### PR TITLE
[linstor-migrator] Set CSI controller finalizer on migrated RV and RVA

### DIFF
--- a/api/v1alpha1/finalizers.go
+++ b/api/v1alpha1/finalizers.go
@@ -24,6 +24,10 @@ const RVControllerFinalizer = "sds-replicated-volume.deckhouse.io/rv-controller"
 
 const RVRControllerFinalizer = "sds-replicated-volume.deckhouse.io/rvr-controller"
 
+// CSIControllerFinalizer is set on ReplicatedVolume and ReplicatedVolumeAttachment
+// by the CSI controller when creating or ensuring those resources.
+const CSIControllerFinalizer = "sds-replicated-volume.deckhouse.io/csi-controller"
+
 // StorageClassFinalizer is set on Kubernetes StorageClass objects managed by
 // the RSC controller. Uses the legacy storage.deckhouse.io prefix for
 // backward compatibility with the old controller.

--- a/e2e/linstor-migrator/go.mod
+++ b/e2e/linstor-migrator/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/deckhouse/sds-node-configurator/api v0.0.0-20260218165228-44f333dae807
 	github.com/deckhouse/sds-replicated-volume/api v0.0.0
 	github.com/deckhouse/storage-e2e v0.0.0-20260507080012-c7702ad03b8a
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	k8s.io/api v0.35.1
@@ -22,8 +23,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.2 // indirect
 	github.com/go-openapi/swag v0.24.1 // indirect
@@ -56,8 +55,6 @@ require (
 	github.com/pkg/sftp v1.13.10 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect

--- a/e2e/linstor-migrator/go.sum
+++ b/e2e/linstor-migrator/go.sum
@@ -253,8 +253,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/e2e/linstor-migrator/tests/helpers/migration.go
+++ b/e2e/linstor-migrator/tests/helpers/migration.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	. "github.com/onsi/ginkgo/v2"
+	"log/slog"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -725,6 +726,24 @@ func CheckRVAPairsMatchInUseVolumesFromSnapshot(snapshot *RVASnapshot) []error {
 	return errors
 }
 
+// CheckRVACSIControllerFinalizerFromSnapshot verifies each RVA has the CSI controller finalizer.
+func CheckRVACSIControllerFinalizerFromSnapshot(snapshot *RVASnapshot) []error {
+	if len(snapshot.ExpectedPairs) == 0 {
+		Skip("Skipping RVA checks: no InUse=true volumes in saved linstor state")
+		return nil
+	}
+	var errors []error
+	for _, rva := range snapshot.CurrentRVAs {
+		if !slices.Contains(rva.Finalizers, srvv1.CSIControllerFinalizer) {
+			errors = append(errors, fmt.Errorf(
+				"RVA %s is missing finalizer %q (finalizers=%v)",
+				rva.Name, srvv1.CSIControllerFinalizer, rva.Finalizers,
+			))
+		}
+	}
+	return errors
+}
+
 func CheckRVANamePatternFromSnapshot(snapshot *RVASnapshot) []error {
 	if len(snapshot.ExpectedPairs) == 0 {
 		Skip("Skipping RVA checks: no InUse=true volumes in saved linstor state")
@@ -1131,6 +1150,24 @@ func CheckRVManualConfigurationFieldsFromSnapshot(snapshot *RVSnapshot, manualEx
 			errors = append(errors, fmt.Errorf(
 				"RV %s has spec.manualConfiguration.volumeAccess=%q (expected PreferablyLocal)",
 				resourceName, mc.VolumeAccess,
+			))
+		}
+	}
+	return errors
+}
+
+// CheckRVCSIControllerFinalizerFromSnapshot verifies each RV has the CSI controller finalizer.
+func CheckRVCSIControllerFinalizerFromSnapshot(snapshot *RVSnapshot) []error {
+	var errors []error
+	for resourceName := range snapshot.UniqueResourceNames {
+		rv, ok := snapshot.RVsByName[resourceName]
+		if !ok {
+			continue
+		}
+		if !slices.Contains(rv.Finalizers, srvv1.CSIControllerFinalizer) {
+			errors = append(errors, fmt.Errorf(
+				"RV %s is missing finalizer %q (finalizers=%v)",
+				resourceName, srvv1.CSIControllerFinalizer, rv.Finalizers,
 			))
 		}
 	}

--- a/e2e/linstor-migrator/tests/migrator_test.go
+++ b/e2e/linstor-migrator/tests/migrator_test.go
@@ -197,6 +197,11 @@ func buildMigratorScenario(scenarioName string, label string, mode helpers.Scena
 					errs := helpers.CheckRVANamePatternFromSnapshot(rvaSnapshot)
 					Expect(errs).To(BeEmpty(), "RVA naming pattern check failed")
 				})
+
+				It("should set CSI controller finalizer on each RVA", func() {
+					errs := helpers.CheckRVACSIControllerFinalizerFromSnapshot(rvaSnapshot)
+					Expect(errs).To(BeEmpty(), "RVA CSI controller finalizer check failed")
+				})
 			})
 
 			Describe("RV resource checks", func() {
@@ -259,6 +264,11 @@ func buildMigratorScenario(scenarioName string, label string, mode helpers.Scena
 				It("should not set no-persistent-volume label on each RV", func() {
 					errs := helpers.CheckRVNoPersistentVolumeLabelAbsentFromSnapshot(rvSnapshot)
 					Expect(errs).To(BeEmpty(), "RV no-persistent-volume label check failed")
+				})
+
+				It("should set CSI controller finalizer on each RV", func() {
+					errs := helpers.CheckRVCSIControllerFinalizerFromSnapshot(rvSnapshot)
+					Expect(errs).To(BeEmpty(), "RV CSI controller finalizer check failed")
 				})
 			})
 
@@ -618,6 +628,11 @@ var _ = Describe("Linstor resources without PV", Ordered, Label("WithoutPV"), fu
 			It("should set no-persistent-volume label on each RV", func() {
 				errs := helpers.CheckRVNoPersistentVolumeLabelFromSnapshot(rvSnapshot)
 				Expect(errs).To(BeEmpty(), "RV no-persistent-volume label check failed")
+			})
+
+			It("should set CSI controller finalizer on each RV", func() {
+				errs := helpers.CheckRVCSIControllerFinalizerFromSnapshot(rvSnapshot)
+				Expect(errs).To(BeEmpty(), "RV CSI controller finalizer check failed")
 			})
 		})
 

--- a/images/csi-driver/pkg/utils/func.go
+++ b/images/csi-driver/pkg/utils/func.go
@@ -37,9 +37,8 @@ import (
 )
 
 const (
-	KubernetesAPIRequestLimit       = 3
-	KubernetesAPIRequestTimeout     = 1
-	SDSReplicatedVolumeCSIFinalizer = "sds-replicated-volume.deckhouse.io/csi-controller"
+	KubernetesAPIRequestLimit   = 3
+	KubernetesAPIRequestTimeout = 1
 )
 
 // CreateReplicatedVolume creates a ReplicatedVolume resource
@@ -54,7 +53,7 @@ func CreateReplicatedVolume(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			OwnerReferences: []metav1.OwnerReference{},
-			Finalizers:      []string{SDSReplicatedVolumeCSIFinalizer},
+			Finalizers:      []string{srv.CSIControllerFinalizer},
 			Annotations: map[string]string{
 				srv.SchedulingReservationIDAnnotationKey:      pvcNamespace + "/" + pvcName,
 				srv.ReplicatedVolumePVCNamespaceAnnotationKey: pvcNamespace,
@@ -191,16 +190,16 @@ func DeleteReplicatedVolume(ctx context.Context, kc client.Client, log *logger.L
 	}
 
 	log.Trace(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] ReplicatedVolume found: %+v", traceID, name, rv))
-	log.Trace(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] Removing finalizer %s if exists", traceID, name, SDSReplicatedVolumeCSIFinalizer))
+	log.Trace(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] Removing finalizer %s if exists", traceID, name, srv.CSIControllerFinalizer))
 
-	removed, err := removervdeletepropagationIfExist(ctx, kc, log, rv, SDSReplicatedVolumeCSIFinalizer)
+	removed, err := removervdeletepropagationIfExist(ctx, kc, log, rv, srv.CSIControllerFinalizer)
 	if err != nil {
 		return fmt.Errorf("remove finalizers from ReplicatedVolume %s: %w", name, err)
 	}
 	if removed {
-		log.Trace(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] finalizer %s removed from ReplicatedVolume %s", traceID, name, SDSReplicatedVolumeCSIFinalizer, name))
+		log.Trace(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] finalizer %s removed from ReplicatedVolume %s", traceID, name, srv.CSIControllerFinalizer, name))
 	} else {
-		log.Warning(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] finalizer %s not found in ReplicatedVolume %s", traceID, name, SDSReplicatedVolumeCSIFinalizer, name))
+		log.Warning(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] finalizer %s not found in ReplicatedVolume %s", traceID, name, srv.CSIControllerFinalizer, name))
 	}
 
 	log.Trace(fmt.Sprintf("[DeleteReplicatedVolume][traceID:%s][volumeID:%s] Trying to delete ReplicatedVolume", traceID, name))
@@ -372,8 +371,8 @@ func EnsureRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceI
 			return "", fmt.Errorf("ReplicatedVolumeAttachment %s is being deleted (phase=%s); cannot publish volume until deletion completes",
 				rvaName, existing.Status.Phase)
 		}
-		if !slices.Contains(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer) {
-			existing.Finalizers = append(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer)
+		if !slices.Contains(existing.Finalizers, srv.CSIControllerFinalizer) {
+			existing.Finalizers = append(existing.Finalizers, srv.CSIControllerFinalizer)
 			if err := kc.Update(ctx, existing); err != nil {
 				return "", fmt.Errorf("add finalizer to ReplicatedVolumeAttachment %s: %w", rvaName, err)
 			}
@@ -387,7 +386,7 @@ func EnsureRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceI
 	rva := &srv.ReplicatedVolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       rvaName,
-			Finalizers: []string{SDSReplicatedVolumeCSIFinalizer},
+			Finalizers: []string{srv.CSIControllerFinalizer},
 		},
 		Spec: srv.ReplicatedVolumeAttachmentSpec{
 			ReplicatedVolumeName: volumeName,
@@ -420,8 +419,8 @@ func DeleteRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceI
 		return fmt.Errorf("ReplicatedVolumeAttachment %s is still in use on node %s, cannot delete", rvaName, nodeName)
 	}
 
-	if slices.Contains(rva.Finalizers, SDSReplicatedVolumeCSIFinalizer) {
-		rva.Finalizers = slices.DeleteFunc(rva.Finalizers, func(s string) bool { return s == SDSReplicatedVolumeCSIFinalizer })
+	if slices.Contains(rva.Finalizers, srv.CSIControllerFinalizer) {
+		rva.Finalizers = slices.DeleteFunc(rva.Finalizers, func(s string) bool { return s == srv.CSIControllerFinalizer })
 		if err := kc.Update(ctx, rva); err != nil {
 			return fmt.Errorf("remove finalizer from ReplicatedVolumeAttachment %s: %w", rvaName, err)
 		}

--- a/images/linstor-migrator/internal/migrator/migrator.go
+++ b/images/linstor-migrator/internal/migrator/migrator.go
@@ -755,7 +755,8 @@ func (m *Migrator) createRVAFromVolumeAttachments(
 		rvaName := fmt.Sprintf("%s-%s-%s", "csi", resName, strings.ToLower(va.Spec.NodeName))
 		rva := &srvv1alpha1.ReplicatedVolumeAttachment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: rvaName,
+				Name:       rvaName,
+				Finalizers: csiControllerFinalizers(),
 			},
 			Spec: srvv1alpha1.ReplicatedVolumeAttachmentSpec{
 				ReplicatedVolumeName: resName,
@@ -863,6 +864,12 @@ func (m *Migrator) checkNewControlPlaneEnabled(ctx context.Context) error {
 	}
 
 	return fmt.Errorf("ModuleConfig %q has newControlPlane=false; enable the new control-plane by setting spec.settings.newControlPlane to true before running migration", config.ModuleName)
+}
+
+// csiControllerFinalizers returns the CSI controller finalizer set on ReplicatedVolume
+// and ReplicatedVolumeAttachment at create time (same as images/csi-driver).
+func csiControllerFinalizers() []string {
+	return []string{srvv1alpha1.CSIControllerFinalizer}
 }
 
 // createIfNotExists creates a Kubernetes resource if it does not already exist.
@@ -1078,6 +1085,7 @@ func (m *Migrator) createRV(
 			Name:        resName,
 			Labels:      labels,
 			Annotations: ann,
+			Finalizers:  csiControllerFinalizers(),
 		},
 		Spec: spec,
 	}

--- a/images/linstor-migrator/internal/migrator/migrator_finalizer_test.go
+++ b/images/linstor-migrator/internal/migrator/migrator_finalizer_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrator
+
+import (
+	"slices"
+	"testing"
+
+	srvv1alpha1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+)
+
+func TestCSIControllerFinalizers(t *testing.T) {
+	t.Parallel()
+
+	got := csiControllerFinalizers()
+	want := []string{srvv1alpha1.CSIControllerFinalizer}
+	if !slices.Equal(got, want) {
+		t.Fatalf("csiControllerFinalizers() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
The linstor-migrator creates ReplicatedVolume and ReplicatedVolumeAttachment objects during migration, but did not set the CSI controller finalizer on them. Without it, the CSI driver cannot manage the deletion lifecycle properly.
- Add CSIControllerFinalizer constant to api/v1alpha1 for shared use
- Replace local SDSReplicatedVolumeCSIFinalizer in csi-driver with shared constant
- Set CSIControllerFinalizer on RV and RVA objects created by the migrator
- Add csiControllerFinalizers() helper with unit test
- Add E2E checks verifying the finalizer is present on migrated RV/RVA

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
