### PR TITLE
[csi-driver] Use api CSIControllerFinalizer everywhere

### DIFF
--- a/images/csi-driver/driver/controller_test.go
+++ b/images/csi-driver/driver/controller_test.go
@@ -80,7 +80,7 @@ func TestControllerUnpublishVolume_WaitsForRVADeletion(t *testing.T) {
 	rva := &v1alpha1.ReplicatedVolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       rvaName,
-			Finalizers: []string{testStuckFinalizer, utils.SDSReplicatedVolumeCSIFinalizer},
+			Finalizers: []string{testStuckFinalizer, v1alpha1.CSIControllerFinalizer},
 		},
 		Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
 			ReplicatedVolumeName: volumeID,
@@ -146,7 +146,7 @@ func TestControllerUnpublishVolume_ReturnsDeadlineExceededIfRVAStuck(t *testing.
 	rva := &v1alpha1.ReplicatedVolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       rvaName,
-			Finalizers: []string{testStuckFinalizer, utils.SDSReplicatedVolumeCSIFinalizer},
+			Finalizers: []string{testStuckFinalizer, v1alpha1.CSIControllerFinalizer},
 		},
 		Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
 			ReplicatedVolumeName: volumeID,
@@ -203,7 +203,7 @@ func createRVPastFormation(t *testing.T, ctx context.Context, cl client.Client, 
 	rv := &v1alpha1.ReplicatedVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       volumeID,
-			Finalizers: []string{utils.SDSReplicatedVolumeCSIFinalizer},
+			Finalizers: []string{v1alpha1.CSIControllerFinalizer},
 		},
 	}
 	if err := cl.Create(ctx, rv); err != nil {
@@ -223,7 +223,7 @@ func createRVStillForming(t *testing.T, ctx context.Context, cl client.Client, v
 	rv := &v1alpha1.ReplicatedVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       volumeID,
-			Finalizers: []string{utils.SDSReplicatedVolumeCSIFinalizer},
+			Finalizers: []string{v1alpha1.CSIControllerFinalizer},
 		},
 	}
 	if err := cl.Create(ctx, rv); err != nil {
@@ -528,7 +528,7 @@ func TestCreateVolume_FreshCreate_WaitFails_DeletionTimestamp_DoesNotDelete(t *t
 	// CreateVolume must NOT have stripped the CSI finalizer as part of a Delete.
 	csiFinalizerFound := false
 	for _, f := range got.Finalizers {
-		if f == utils.SDSReplicatedVolumeCSIFinalizer {
+		if f == v1alpha1.CSIControllerFinalizer {
 			csiFinalizerFound = true
 			break
 		}

--- a/images/csi-driver/driver/controller_test.go
+++ b/images/csi-driver/driver/controller_test.go
@@ -198,7 +198,7 @@ func newCreateVolumeRequest(volumeID string) *csi.CreateVolumeRequest {
 }
 
 // createRVPastFormation pre-creates an RV and marks its status as past Formation.
-func createRVPastFormation(t *testing.T, ctx context.Context, cl client.Client, volumeID string) *v1alpha1.ReplicatedVolume {
+func createRVPastFormation(ctx context.Context, t *testing.T, cl client.Client, volumeID string) *v1alpha1.ReplicatedVolume {
 	t.Helper()
 	rv := &v1alpha1.ReplicatedVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -218,7 +218,7 @@ func createRVPastFormation(t *testing.T, ctx context.Context, cl client.Client, 
 
 // createRVStillForming pre-creates an RV with empty status so the predicate
 // IsReplicatedVolumePastFormation is false for it.
-func createRVStillForming(t *testing.T, ctx context.Context, cl client.Client, volumeID string) *v1alpha1.ReplicatedVolume {
+func createRVStillForming(ctx context.Context, t *testing.T, cl client.Client, volumeID string) *v1alpha1.ReplicatedVolume {
 	t.Helper()
 	rv := &v1alpha1.ReplicatedVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -233,7 +233,7 @@ func createRVStillForming(t *testing.T, ctx context.Context, cl client.Client, v
 }
 
 // formRVAsync marks the RV past Formation after a delay, letting the Wait loop observe it.
-func formRVAsync(t *testing.T, ctx context.Context, cl client.Client, volumeID string, after time.Duration) chan struct{} {
+func formRVAsync(ctx context.Context, t *testing.T, cl client.Client, volumeID string, after time.Duration) chan struct{} {
 	t.Helper()
 	done := make(chan struct{})
 	go func() {
@@ -270,7 +270,7 @@ func TestCreateVolume_AlreadyExists_PastFormation_ReturnsSuccessWithoutWait(t *t
 
 	volumeID := "rv-already-formed"
 	cl := newTestFakeClient()
-	createRVPastFormation(t, ctx, cl, volumeID)
+	createRVPastFormation(ctx, t, cl, volumeID)
 
 	// waitActionTimeout is intentionally large. If we accidentally enter Wait,
 	// we still expect Wait to finish quickly because DatameshRevision>0 already,
@@ -301,11 +301,11 @@ func TestCreateVolume_AlreadyExists_StillForming_WaitSucceeds(t *testing.T) {
 
 	volumeID := "rv-forming-ok"
 	cl := newTestFakeClient()
-	createRVStillForming(t, ctx, cl, volumeID)
+	createRVStillForming(ctx, t, cl, volumeID)
 
 	d := newTestDriver(t, cl, 5*time.Second)
 
-	done := formRVAsync(t, ctx, cl, volumeID, 300*time.Millisecond)
+	done := formRVAsync(ctx, t, cl, volumeID, 300*time.Millisecond)
 
 	resp, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
 	<-done
@@ -327,7 +327,7 @@ func TestCreateVolume_AlreadyExists_StillForming_WaitFails_DeletesGarbage(t *tes
 
 	volumeID := "rv-forming-stuck"
 	cl := newTestFakeClient()
-	createRVStillForming(t, ctx, cl, volumeID)
+	createRVStillForming(ctx, t, cl, volumeID)
 
 	d := newTestDriver(t, cl, 200*time.Millisecond)
 
@@ -351,7 +351,7 @@ func TestCreateVolume_AlreadyExists_BeingDeleted_ReturnsAborted(t *testing.T) {
 
 	volumeID := "rv-being-deleted"
 	cl := newTestFakeClient()
-	rv := createRVStillForming(t, ctx, cl, volumeID)
+	rv := createRVStillForming(ctx, t, cl, volumeID)
 	// Delete; fake client keeps the object around (finalizer) with DeletionTimestamp.
 	if err := cl.Delete(ctx, rv); err != nil {
 		t.Fatalf("delete rv: %v", err)
@@ -384,7 +384,7 @@ func TestCreateVolume_FreshCreate_WaitSucceeds_ReturnsResponse(t *testing.T) {
 
 	d := newTestDriver(t, cl, 5*time.Second)
 
-	done := formRVAsync(t, ctx, cl, volumeID, 300*time.Millisecond)
+	done := formRVAsync(ctx, t, cl, volumeID, 300*time.Millisecond)
 
 	resp, err := d.CreateVolume(ctx, newCreateVolumeRequest(volumeID))
 	<-done
@@ -457,7 +457,7 @@ func TestCreateVolume_WaitFails_RaceWin_ReturnsSuccess(t *testing.T) {
 		}).
 		Build()
 
-	createRVStillForming(t, ctx, cl, volumeID)
+	createRVStillForming(ctx, t, cl, volumeID)
 
 	// waitActionTimeout=1ns forces Wait to return ctx.Err immediately in its
 	// first select iteration, without ever Get-ing the RV itself (otherwise

--- a/images/csi-driver/pkg/utils/func.go
+++ b/images/csi-driver/pkg/utils/func.go
@@ -428,8 +428,8 @@ func EnsureRVA(ctx context.Context, kc client.Client, log *logger.Logger, traceI
 		return createRVA(ctx, kc, log, traceID, volumeName, nodeName)
 	}
 
-	if !slices.Contains(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer) {
-		existing.Finalizers = append(existing.Finalizers, SDSReplicatedVolumeCSIFinalizer)
+	if !slices.Contains(existing.Finalizers, srv.CSIControllerFinalizer) {
+		existing.Finalizers = append(existing.Finalizers, srv.CSIControllerFinalizer)
 		if uerr := kc.Update(ctx, existing); uerr != nil {
 			return "", fmt.Errorf("add finalizer to ReplicatedVolumeAttachment %s: %w", rvaName, uerr)
 		}
@@ -699,4 +699,3 @@ func WaitForRVADeleted(
 		}
 	}
 }
-

--- a/images/csi-driver/pkg/utils/func_publish_test.go
+++ b/images/csi-driver/pkg/utils/func_publish_test.go
@@ -243,7 +243,7 @@ var _ = Describe("WaitForRVADeleted", func() {
 			rva := &v1alpha1.ReplicatedVolumeAttachment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       rvaName,
-					Finalizers: []string{stuckFinalizer, SDSReplicatedVolumeCSIFinalizer},
+					Finalizers: []string{stuckFinalizer, v1alpha1.CSIControllerFinalizer},
 				},
 				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
 					ReplicatedVolumeName: volumeName,
@@ -359,7 +359,7 @@ var _ = Describe("EnsureRVA with stale deleting RVA", func() {
 			stale := &v1alpha1.ReplicatedVolumeAttachment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       rvaName,
-					Finalizers: []string{stuckFinalizer, SDSReplicatedVolumeCSIFinalizer},
+					Finalizers: []string{stuckFinalizer, v1alpha1.CSIControllerFinalizer},
 				},
 				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
 					ReplicatedVolumeName: volumeName,
@@ -388,7 +388,7 @@ var _ = Describe("EnsureRVA with stale deleting RVA", func() {
 			fresh := &v1alpha1.ReplicatedVolumeAttachment{}
 			Expect(cl.Get(ctx, client.ObjectKey{Name: rvaName}, fresh)).To(Succeed())
 			Expect(fresh.DeletionTimestamp).To(BeNil())
-			Expect(fresh.Finalizers).To(ContainElement(SDSReplicatedVolumeCSIFinalizer))
+			Expect(fresh.Finalizers).To(ContainElement(v1alpha1.CSIControllerFinalizer))
 		})
 	})
 
@@ -401,7 +401,7 @@ var _ = Describe("EnsureRVA with stale deleting RVA", func() {
 			stale := &v1alpha1.ReplicatedVolumeAttachment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       rvaName,
-					Finalizers: []string{stuckFinalizer, SDSReplicatedVolumeCSIFinalizer},
+					Finalizers: []string{stuckFinalizer, v1alpha1.CSIControllerFinalizer},
 				},
 				Spec: v1alpha1.ReplicatedVolumeAttachmentSpec{
 					ReplicatedVolumeName: volumeName,
@@ -439,4 +439,3 @@ func newFakeClient() client.Client {
 		WithStatusSubresource(&v1alpha1.ReplicatedVolumeAttachment{})
 	return builder.Build()
 }
-

--- a/images/linstor-migrator/go.mod
+++ b/images/linstor-migrator/go.mod
@@ -59,6 +59,7 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/images/linstor-migrator/internal/linstorbackup/embed_release.go
+++ b/images/linstor-migrator/internal/linstorbackup/embed_release.go
@@ -1,3 +1,5 @@
+//go:build embed_linstor_viewer
+
 /*
 Copyright 2026 Flant JSC
 

--- a/images/linstor-migrator/internal/linstorbackup/embed_stub.go
+++ b/images/linstor-migrator/internal/linstorbackup/embed_stub.go
@@ -1,0 +1,23 @@
+//go:build !embed_linstor_viewer
+
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linstorbackup
+
+// embeddedLinstor is empty unless the migrator is built with -tags embed_linstor_viewer
+// and internal/linstorbackup/embedded/linstor-viewer is present (see embedded/README.md).
+var embeddedLinstor []byte

--- a/images/linstor-migrator/internal/linstorbackup/embedded/README.md
+++ b/images/linstor-migrator/internal/linstorbackup/embedded/README.md
@@ -1,12 +1,16 @@
 # Embedded `linstor-viewer` binary
 
-The file `linstor-viewer` is produced at image/build time and embedded into the migrator binary via `go:embed`. Do not commit the binary (see `.gitignore`).
+The file `linstor-viewer` is produced at image/build time and embedded into the migrator binary via `go:embed` when building with `-tags embed_linstor_viewer`. Do not commit the binary (see `.gitignore`).
 
-## Werf / CI
+## Werf / production build
 
-`images/linstor-migrator/werf.inc.yaml` builds the viewer first, copies it here, then builds the migrator so `go:embed` succeeds.
+`images/linstor-migrator/werf.inc.yaml` builds the viewer first, copies it here, then builds the migrator with `-tags embed_linstor_viewer` so `go:embed` succeeds.
 
-## Local development
+## Unit tests and local `go test`
+
+Tests compile without `embedded/linstor-viewer`: the default build uses an empty stub (`embed_stub.go`). No pre-build step is required for `go test ./...`.
+
+## Local migrator binary (with embedded viewer)
 
 From the repository root:
 
@@ -15,13 +19,9 @@ cd images/linstor-migrator
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" \
   -o internal/linstorbackup/embedded/linstor-viewer ./cmd/linstor-viewer
 chmod 0755 internal/linstorbackup/embedded/linstor-viewer
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags embed_linstor_viewer -ldflags="-s -w" \
+  -o /tmp/linstor-migrator ./cmd
 ```
 
-Then build or test the migrator as usual, for example:
-
-```bash
-go test ./...
-go build -o /tmp/linstor-migrator ./cmd
-```
-
-Without `embedded/linstor-viewer`, `go build` of the migrator fails on the embed directive.
+Without `embedded/linstor-viewer`, `go build -tags embed_linstor_viewer` fails on the embed directive.
+A plain `go build ./cmd` (no tag) produces a migrator without an embedded viewer; backup install will error at runtime if the viewer is required.

--- a/images/linstor-migrator/werf.inc.yaml
+++ b/images/linstor-migrator/werf.inc.yaml
@@ -40,7 +40,7 @@ shell:
     - cd /src/images/{{ $.ImageName }}
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /tmp/linstor-viewer ./cmd/linstor-viewer
     - install -Dm 0755 /tmp/linstor-viewer ./internal/linstorbackup/embedded/linstor-viewer
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /{{ $.ImageName }} ./cmd
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags embed_linstor_viewer -ldflags="-s -w" -o /{{ $.ImageName }} ./cmd
     - chmod +x /{{ $.ImageName }}
 
 ---


### PR DESCRIPTION
Complete the migration from the removed utils.SDSReplicatedVolumeCSIFinalizer to api/v1alpha1.CSIControllerFinalizer.

- Fix EnsureRVA: use srv.CSIControllerFinalizer when patching existing RVA
- Update controller_test.go and func_publish_test.go to reference v1alpha1.CSIControllerFinalizer

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
