### PR TITLE
docs: bump sds-replicated-volume ModuleConfig examples to version 2

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -653,7 +653,7 @@ linstor resource list --faulty
      name: sds-replicated-volume
    spec:
      enabled: true
-     version: 1
+     version: 2
    EOF
    ```
 
@@ -755,7 +755,7 @@ Note that the module control-plane and its CSI will be unavailable during the mi
      name: sds-replicated-volume
    spec:
      enabled: true
-     version: 1
+     version: 2
    EOF
    ```
 

--- a/docs/FAQ_RU.md
+++ b/docs/FAQ_RU.md
@@ -686,7 +686,7 @@ linstor resource list --faulty
      name: sds-replicated-volume
    spec:
      enabled: true
-     version: 1
+     version: 2
    EOF
    ```
 
@@ -788,7 +788,7 @@ StorageClass'ы в данном модуле управляются через �
      name: sds-replicated-volume
    spec:
      enabled: true
-     version: 1
+     version: 2
    EOF
    ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ Enabling the `sds-node-configurator` module:
      name: sds-replicated-volume
    spec:
      enabled: true
-     version: 1
+     version: 2
    EOF
    ```
    

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -97,7 +97,7 @@ moduleStatus: preview
      name: sds-replicated-volume
    spec:
      enabled: true
-     version: 1
+     version: 2
    EOF
    ```
   


### PR DESCRIPTION
## Description

The module's openapi (`openapi/config-values.yaml`) declares `x-config-version: 2`, and the only conversion present (`openapi/conversions/v2.yaml`) targets version 2 (it removes the deprecated `enableThinProvisioning` parameter — see CHANGELOG `v0.8.15`). User-facing docs, however, still showed `ModuleConfig/sds-replicated-volume` snippets with `spec.version: 1`.

This PR brings the `sds-replicated-volume` `ModuleConfig` examples in line with the actual CR / openapi version:

- `docs/README.md`, `docs/README_RU.md` — quick-start enabling snippet now uses `spec.version: 2`.
- `docs/FAQ.md`, `docs/FAQ_RU.md` — both `sds-replicated-volume` `ModuleConfig` snippets in the `linstor → sds-replicated-volume` and `sds-drbd → sds-replicated-volume` migration sections now use `spec.version: 2`.

`ModuleConfig` examples for `sds-node-configurator` are intentionally left untouched: that module currently has no `x-config-version` in `openapi/config-values.yaml` and stays at the implicit version `1`.

No code, hooks, CRDs, helm templates, or runtime behavior are touched — documentation only.

## Why do we need it, and what problem does it solve?

A user following the docs verbatim would create a `ModuleConfig/sds-replicated-volume` pinned to the deprecated v1 schema. Deckhouse then converts it to v2, but:

- the displayed `spec.version: 1` no longer matches the module's `x-config-version: 2`;
- the v2 conversion explicitly removes `enableThinProvisioning`, so authoring against v1 in 2026 is just legacy noise;
- on `kubectl get moduleconfig sds-replicated-volume -oyaml` the user would see `version: 2`, which contradicts the snippet they just applied.

## What is the expected result?

- Diff is documentation-only; rendered README and FAQ (en/ru) show `spec.version: 2` for every `ModuleConfig/sds-replicated-volume` example.
- `ModuleConfig/sds-node-configurator` examples are intentionally unchanged.
- After this PR the snippets are consistent with `openapi/config-values.yaml` (`x-config-version: 2`) and `openapi/conversions/v2.yaml`.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.