### PR TITLE
[build] Update DRBD to 9.2.18

### DIFF
--- a/openapi/values_ce.yaml
+++ b/openapi/values_ce.yaml
@@ -15,7 +15,7 @@ properties:
     properties:
       drbdVersion:
         type: string
-        default: "9.2.16"
+        default: "9.2.18"
       dataNodesChecksum:
         type: string
         default: "default_data_nodes_checksum"

--- a/openapi/values_ee.yaml
+++ b/openapi/values_ee.yaml
@@ -15,7 +15,7 @@ properties:
     properties:
       drbdVersion:
         type: string
-        default: "9.2.16"
+        default: "9.2.18"
       dataNodesChecksum:
         type: string
         default: "default_data_nodes_checksum"

--- a/oss.yaml
+++ b/oss.yaml
@@ -6,7 +6,7 @@
   license: GPL-2.0
 
 - id: DRBD
-  version: "9.2.16"
+  version: "9.2.18"
   name: DRBD
   link: https://github.com/LINBIT/drbd
   description: DRBD, developed by LINBIT, provides networked RAID 1 functionality for GNU/Linux. It is designed for high availability clusters and software defined storage.


### PR DESCRIPTION
## Description

This PR updates the DRBD kernel module version from `9.2.16` to `9.2.18`.

The default internal `drbdVersion` value is updated for both CE and EE configuration schemas so new installations and generated module values use the same DRBD version as the build configuration.

## Why do we need it, and what problem does it solve?

The module should test and use DRBD `9.2.18` instead of `9.2.16`. This keeps the packaged DRBD kernel module aligned with the target version for validation and future rollout.

## What is the expected result?

After applying this change:

- DRBD image build uses the `drbd-9.2.18` branch from the configured DRBD source repository.
- Default module values expose `drbdVersion: "9.2.18"` for CE and EE.
- Nodes should install or wait for DRBD `9.2.18` according to the existing module installation flow.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
