### PR TITLE
chore(werf): migrate to container-base v1.0.51

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -93,6 +93,13 @@ linters-settings:
   images:
     patches:
       disable: true
+  module:
+    exclude-rules:
+      oss:
+        version-not-semver:
+          - id: LINSTOR_COMMON
+          - id: LINSTOR_CSI
+          - id: LINSTOR_SERVER_PIRAEUS
   no-cyrillic:
     exclude-rules:
       directories:

--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -93,3 +93,7 @@ linters-settings:
   images:
     patches:
       disable: true
+  no-cyrillic:
+    exclude-rules:
+      directories:
+        - hack/

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request
@@ -122,7 +122,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   push:
     tags:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -82,7 +82,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -125,7 +125,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -168,7 +168,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -211,7 +211,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/translate-changelog.yml
+++ b/.github/workflows/translate-changelog.yml
@@ -2,7 +2,7 @@ name: Translate Changelog and Create PR
 
 on:
   push:
-    # Запуск для всех веток при любом push
+    # Run for all branches on any push
 
 jobs:
   translate-and-pr:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__/
 images/sds-replicated-volume-controller/dev/Dockerfile-dev
 images/sds-replicated-volume-controller/src/Makefile
 hack.sh
+base_images.yml

--- a/.werf/base-images.yaml
+++ b/.werf/base-images.yaml
@@ -1,7 +1,7 @@
 # Base Images
 {{- $baseImages := .Files.Get "base_images.yml" | fromYaml }}
 {{- range $k, $v := $baseImages }}
-  {{ $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
+  {{- $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
   {{- if ne $k "REGISTRY_PATH" }}
     {{- $_ := set $baseImages $k $baseImagePath }}
   {{- end }}
@@ -9,11 +9,3 @@
 {{- $_ := unset $baseImages "REGISTRY_PATH" }}
 
 {{- $_ := set . "Images" $baseImages }}
-# base images artifacts
-{{- range $k, $v := .Images }}
----
-image: {{ $k }}
-from: {{ $v }}
-final: false
-{{- end }}
-

--- a/.werf/bundle.yaml
+++ b/.werf/bundle.yaml
@@ -1,6 +1,6 @@
 ---
 image: docs-generator
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -25,7 +25,7 @@ shell:
 # Bundle image, stored in your.registry.io/modules/<module-name>:<semver>
 ---
 image: bundle
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 
 import:
   # Rendering .werf/images-digests.yaml is required!

--- a/.werf/choose-edition.yaml
+++ b/.werf/choose-edition.yaml
@@ -1,18 +1,16 @@
 ---
 image: choose-edition
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 fromCacheVersion: {{ div .Commit.Date.Unix (mul 60 60 24 30) }}
 
 git:
-  - add: /
-    to: /
-    includePaths:
-      - openapi
+  - add: /openapi
+    to: /openapi
     stageDependencies:
       setup:
-        - openapi/values_*.yaml      
+        - '**/*'
 shell:
   setup:
     - cd /openapi
-    - if [[ {{ .MODULE_EDITION }} == "ce" ]]; then cp -v values_ce.yaml values.yaml; else cp -v values_ee.yaml values.yaml; fi
+    - if [[ {{ .MODULE_EDITION }} == "ce" ]]; then cp -fv values_ce.yaml values.yaml; fi
     - rm -rf values_*.yaml

--- a/.werf/consts.yaml
+++ b/.werf/consts.yaml
@@ -1,15 +1,6 @@
 # Edition module settings, default ce
 {{- $_ := set . "MODULE_EDITION" (env "MODULE_EDITION" "ce") }}
 
-# base images
-{{- $_ := set $ "BASE_ALPINE_DEV"  "registry.deckhouse.io/base_images/dev-alpine:3.16.3@sha256:c706fa83cc129079e430480369a3f062b8178cac9ec89266ebab753a574aca8e" }}
-{{- $_ := set $ "BASE_ALT"         "registry.deckhouse.io/base_images/alt:p10@sha256:f105773c682498700680d7cd61a702a4315c4235aee3622757591fd510fb8b4a" }}
-{{- $_ := set $ "BASE_ALT_P11"     "registry.deckhouse.io/base_images/alt:p11@sha256:c396cd7348a48f9236413e2ef5569223c15e554c0a3ca37f9d92fb787d4f1893" }}
-{{- $_ := set $ "BASE_GOLANG_1_22" "registry.deckhouse.io/base_images/golang:1.22.7-bullseye@sha256:e5dc67bf84590c008338a0e30f56a6ed2092a38e0d2895c797dd501db73a2330" }}
-{{- $_ := set $ "BASE_GOLANG_1_23" "registry.deckhouse.io/base_images/golang:1.23.6-alpine3.20@sha256:3058c63e0e2532881949c4186414baa24a0f9a8f9349b1853daa49be816f42e9" }}
-{{- $_ := set $ "BASE_PYTHON"      "registry.deckhouse.io/base_images/python:3.7.16-alpine3.16@sha256:054c898ee5eacb0b3d85bdb603d6229b93619964cc01be5274acdf3e451e5ef8" }}
-{{- $_ := set $ "BASE_SCRATCH"     "registry.deckhouse.io/base_images/scratch@sha256:653ae76965c98c8cd1c8c9ff7725316d2983986f896655b30e0f44d2f8b2dd7e" }}
-
 {{- $_ := set $ "SOURCE_REPO" (env "SOURCE_REPO" "https://github.com") }}
 
 # custom constants

--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -13,9 +13,9 @@
 # Images Digest: a files with all image digests to be able to use them in helm templates of a module
 ---
 image: images-digests
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 import:
-  - image: tools/jq
+  - from: {{ index $.Images "jq" }}
     add: /usr/bin/jq
     to: /usr/bin/jq
     before: setup

--- a/.werf/images.yaml
+++ b/.werf/images.yaml
@@ -2,7 +2,15 @@
 {{- $Root := . }}
 
 {{- range $path, $content := $ImagesBuildFiles  }}
-  {{- $ctx := dict "ImageName" ($path | split "/")._1 "Root" $Root "Versions" $Root.VERSIONS "Files" $Root.Files "SOURCE_REPO" $Root.SOURCE_REPO "GOPROXY" $Root.GOPROXY "DistroPackagesProxy" $Root.DistroPackagesProxy }}
+  {{- $ctx := dict }}
+  {{- $_ := set $ctx "ImageName" ($path | split "/")._1 }}
+  {{- $_ := set $ctx "Images" $.Images }}
+  {{- $_ := set $ctx "Root" $Root }}
+  {{- $_ := set $ctx "SOURCE_REPO" $Root.SOURCE_REPO }}
+  {{- $_ := set $ctx "GOPROXY" $Root.GOPROXY }}
+  {{- $_ := set $ctx "DistroPackagesProxy" $Root.DistroPackagesProxy }}
+  {{- $_ := set $ctx "Versions" $Root.VERSIONS }}
+  {{- $_ := set $ctx "Files" $Root.Files }}
 ---
   {{- /* For Dockerfile just render it from the folder. */ -}}
   {{- if not (regexMatch "/werf.inc.yaml$" $path) }}

--- a/.werf/release.yaml
+++ b/.werf/release.yaml
@@ -1,7 +1,7 @@
 # Release image, stored in your.registry.io/modules/<module-name>/release:<semver>
 ---
 image: release-channel-version-artifact
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 final: false
 git:
 - add: /
@@ -13,7 +13,7 @@ git:
     setup:
     - '**/*'
 import:
-  - image: tools/yq
+  - from: {{ index $.Images "yq" }}
     add: /usr/bin/yq
     to: /usr/bin/yq
     before: install
@@ -24,7 +24,7 @@ shell:
     - cp -f CHANGELOG/{{ env "MODULES_MODULE_TAG" "local" }}.yml /changelog.yaml || touch /changelog.yaml
 ---
 image: release-channel-version
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 import:
   - image: release-channel-version-artifact
     add: /

--- a/.werf/utils.yaml
+++ b/.werf/utils.yaml
@@ -44,8 +44,8 @@
     {{- end }}
 
     if [ ${#SUBMODULES_BRANCHES[@]} -eq 0 ]; then
-      # Без кастомных веток — checkout по gitlink родительского коммита.
-      # submodule add -b master перезаписывает gitlink и ломает сборку (drbd-headers).
+      # No custom branches — checkout submodules from the parent commit gitlink.
+      # submodule add -b master overwrites the gitlink and breaks the build (drbd-headers).
       git -C "{{ .folder }}" config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
           while read -r KEY MODULE_PATH
           do

--- a/.werf/utils.yaml
+++ b/.werf/utils.yaml
@@ -38,45 +38,60 @@
     # .submodules is a string like "submodule1-name=submodule1-branch submodule2-name="
     # If branch is not set then using branch from .git-submodules file
     {{- range $submod := $.submodules | default "" | splitList " " }}
+    {{- if $submod }}
     SUBMODULES_BRANCHES+=( {{ $submod }} )
     {{- end }}
+    {{- end }}
 
-    echo "Processing submodules: ${SUBMODULES_BRANCHES[@]}"
-    git -C "{{ .folder }}" config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
-        while read -r KEY MODULE_PATH
-        do
-            # If the module's path exists, remove it.
-            # This is done b/c the module's path is currently
-            # not a valid git repo and adding the submodule will cause an error.
-            [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
-
-            NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
-
-            url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
-            branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
-
-            URL="$(git config -f .gitmodules --get "${url_key}")"
-            BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
-
-            git -C "{{ .folder }}" submodule add --force -b "${BRANCH}" --name "${NAME}" -- "${URL}" "${MODULE_PATH}"
-
-            for submod in "${SUBMODULES_BRANCHES[@]}"; do
-              submod_name=${submod%=*}
-              submod_branch=${submod#*=}
-
-              if [ -n "${submod_branch}" -a "${NAME}"=="${submod_name}" ]; then
-                echo "Checkout branch/commit '${submod_branch}' for submodule '${NAME}'"
-                git -C "{{ .folder }}" submodule set-branch --branch ${submod_branch} -- ${MODULE_PATH}
-                git -C "{{ .folder }}/${MODULE_PATH}" checkout -f ${submod_branch}
+    if [ ${#SUBMODULES_BRANCHES[@]} -eq 0 ]; then
+      # Без кастомных веток — checkout по gitlink родительского коммита.
+      # submodule add -b master перезаписывает gitlink и ломает сборку (drbd-headers).
+      git -C "{{ .folder }}" config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+          while read -r KEY MODULE_PATH
+          do
+              if [ -d "${MODULE_PATH}" ] && [ ! -e "${MODULE_PATH}/.git" ]; then
+                rm -rf "${MODULE_PATH}"
               fi
-            done
-        done
-    # DO NOT do submodule update, or it revert all changes for submodule's branches back :-(
-    # git -C "{{ .folder }}" submodule update --init --recursive
+          done
+      git -C "{{ .folder }}" submodule update --init --recursive
+    else
+      echo "Processing submodules with custom branches: ${SUBMODULES_BRANCHES[@]}"
+      git -C "{{ .folder }}" config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+          while read -r KEY MODULE_PATH
+          do
+              # If the module's path exists, remove it.
+              # This is done b/c the module's path is currently
+              # not a valid git repo and adding the submodule will cause an error.
+              [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
 
-    if ! tmp=$(git diff --name-status HEAD 2>&1) || test -n "$tmp" ; then
-      echo "Auto-commit changes in .gitmodules"
-      git -C "{{ .folder }}" commit -am "Auto-commit changes in .gitmodules"
+              NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+              url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+              branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+              URL="$(git config -f .gitmodules --get "${url_key}")"
+              BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+              git -C "{{ .folder }}" submodule add --force -b "${BRANCH}" --name "${NAME}" -- "${URL}" "${MODULE_PATH}"
+
+              for submod in "${SUBMODULES_BRANCHES[@]}"; do
+                submod_name=${submod%=*}
+                submod_branch=${submod#*=}
+
+                if [ -n "${submod_branch}" -a "${NAME}"=="${submod_name}" ]; then
+                  echo "Checkout branch/commit '${submod_branch}' for submodule '${NAME}'"
+                  git -C "{{ .folder }}" submodule set-branch --branch ${submod_branch} -- ${MODULE_PATH}
+                  git -C "{{ .folder }}/${MODULE_PATH}" checkout -f ${submod_branch}
+                fi
+              done
+          done
+      # DO NOT do submodule update, or it revert all changes for submodule's branches back :-(
+      # git -C "{{ .folder }}" submodule update --init --recursive
+
+      if ! tmp=$(git diff --name-status HEAD 2>&1) || test -n "$tmp" ; then
+        echo "Auto-commit changes in .gitmodules"
+        git -C "{{ .folder }}" commit -am "Auto-commit changes in .gitmodules"
+      fi
     fi
 {{ end }}
 

--- a/.werf/utils.yaml
+++ b/.werf/utils.yaml
@@ -192,7 +192,21 @@
       ls -la "${TARBALL_DIR}" || true
       exit 1
     fi
-    mv "${TARBALL}" "/home/rpmbuilder/RPM/SOURCES/{{ .name }}-{{ .version }}.tar.gz"
+    TARGET="/home/rpmbuilder/RPM/SOURCES/{{ .name }}-{{ .version }}.tar.gz"
+    TARGET_DIR="{{ .name }}-{{ .version }}"
+    TMPDIR=$(mktemp -d)
+    tar -xzf "${TARBALL}" -C "${TMPDIR}"
+    SRCDIR=$(find "${TMPDIR}" -mindepth 1 -maxdepth 1 -type d | head -1)
+    if [ -z "${SRCDIR}" ]; then
+      echo "Tarball has no top-level directory: ${TARBALL}"
+      ls -la "${TMPDIR}" || true
+      exit 1
+    fi
+    if [ "$(basename "${SRCDIR}")" != "${TARGET_DIR}" ]; then
+      mv "${SRCDIR}" "${TMPDIR}/${TARGET_DIR}"
+    fi
+    tar -czf "${TARGET}" -C "${TMPDIR}" "${TARGET_DIR}"
+    rm -rf "${TMPDIR}"
   - mv {{ .spec }} /home/rpmbuilder/RPM/SPECS
   - cd /home/rpmbuilder/RPM/SPECS
   - SPEC_FILE=$(basename "{{ .spec }}")

--- a/.werf/utils.yaml
+++ b/.werf/utils.yaml
@@ -192,7 +192,7 @@
       ls -la "${TARBALL_DIR}" || true
       exit 1
     fi
-    mv "${TARBALL}" /home/rpmbuilder/RPM/SOURCES/
+    mv "${TARBALL}" "/home/rpmbuilder/RPM/SOURCES/{{ .name }}-{{ .version }}.tar.gz"
   - mv {{ .spec }} /home/rpmbuilder/RPM/SPECS
   - cd /home/rpmbuilder/RPM/SPECS
   - SPEC_FILE=$(basename "{{ .spec }}")

--- a/.werf/utils.yaml
+++ b/.werf/utils.yaml
@@ -181,7 +181,18 @@
   - chown -R rpmbuilder:rpmbuilder .
   # we need tarball first
   - sudo -u rpmbuilder ${TARBALL_CMD} KEEPNAME=1 VERSION={{ .version }}
-  - mv {{ printf "%s/" (.gen_path | default ".") }}{{ .name }}-{{ .version }}.tar.gz /home/rpmbuilder/RPM/SOURCES/
+  - |
+    TARBALL_DIR="{{ printf "%s/" (.gen_path | default ".") }}"
+    TARBALL="${TARBALL_DIR}{{ .name }}-{{ .version }}.tar.gz"
+    if [ ! -f "${TARBALL}" ]; then
+      TARBALL="${TARBALL_DIR}$(echo '{{ .name }}' | tr '-' '_')-{{ .version }}.tar.gz"
+    fi
+    if [ ! -f "${TARBALL}" ]; then
+      echo "Tarball not found: expected {{ .name }}-{{ .version }}.tar.gz in ${TARBALL_DIR}"
+      ls -la "${TARBALL_DIR}" || true
+      exit 1
+    fi
+    mv "${TARBALL}" /home/rpmbuilder/RPM/SOURCES/
   - mv {{ .spec }} /home/rpmbuilder/RPM/SPECS
   - cd /home/rpmbuilder/RPM/SPECS
   - SPEC_FILE=$(basename "{{ .spec }}")

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SHELL := /bin/bash
 
+.PHONY: update-base-images-versions
+update-base-images-versions:
+	##~ Options: version=vMAJOR.MINOR.PATCH
+	curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml
+
 .PHONY: update-dev
 update-dev: check-yq
 	make bump-dev version=$$(./hack/increase_semver.sh -d $$(yq .version Chart.yaml))

--- a/images/controller/werf.inc.yaml
+++ b/images/controller/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-src-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -21,7 +21,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 import:
@@ -47,7 +47,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 import:
   - image: {{ $.ImageName }}-golang-artifact

--- a/images/drbd-reactor/patches/002-fix-rust-dangerous-implicit-autorefs.patch
+++ b/images/drbd-reactor/patches/002-fix-rust-dangerous-implicit-autorefs.patch
@@ -1,0 +1,12 @@
+diff --git a/drbd-reactor.spec b/drbd-reactor.spec
+index 3f53501..96d2efa 100644
+--- a/drbd-reactor.spec
++++ b/drbd-reactor.spec
+@@ -26,6 +26,7 @@ Plugins can for example monitor resources or promote DRBD resources.
+ 
+ 
+ %build
++export RUSTFLAGS="-A dangerous_implicit_autorefs"
+ make %{?_smp_mflags}
+ 
+ 

--- a/images/drbd-reactor/patches/Readme.md
+++ b/images/drbd-reactor/patches/Readme.md
@@ -3,3 +3,7 @@
 ## fix-drbd-reactor-spec.patch
 
 Remove systemd build-requirement because ALTLinux is based on SysV, not Systemd.
+
+## fix-rust-dangerous-implicit-autorefs.patch
+
+Отключить lint `dangerous_implicit_autorefs` при сборке на Rust из нового ALT (clap 2 + `crate_authors!`).

--- a/images/drbd-reactor/werf.inc.yaml
+++ b/images/drbd-reactor/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # build drbd-utils .deb packages
 image: {{ $.ImageName }}-utils-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -83,7 +83,7 @@ shell:
 ---
 # build drbd-reactor .rpm packages
 image: {{ $.ImageName }}-reactor-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -140,7 +140,7 @@ shell:
 ---
 # main almost distroless image
 image: {{ $.ImageName }}
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 import:
   - image: {{ $.ImageName }}-utils-artifact
     add: /

--- a/images/drbd/werf.inc.yaml
+++ b/images/drbd/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-artifact
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 git:
   - add: /images/{{ $.ImageName }}/scripts
@@ -38,7 +38,7 @@ shell:
     - rm -rf .git
 ---
 image: {{ $.ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 import:
   - image: {{ $.ImageName }}-artifact

--- a/images/go-hooks/werf.inc.yaml
+++ b/images/go-hooks/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 git:

--- a/images/linstor-affinity-controller/werf.inc.yaml
+++ b/images/linstor-affinity-controller/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 git:
@@ -37,7 +37,7 @@ shell:
     - chmod +x /{{ $.ImageName }}
 ---
 image: {{ $.ImageName }}
-from: {{ $.Root.BASE_SCRATCH }}
+from: {{ index $.Images "builder/scratch" }}
 
 import:
   - image: {{ $.ImageName }}-golang-artifact

--- a/images/linstor-affinity-controller/werf.inc.yaml
+++ b/images/linstor-affinity-controller/werf.inc.yaml
@@ -27,7 +27,7 @@ secrets:
 
 shell:
   setup:    
-    - apk add --no-cache git
+    - pm install git
     - cd /usr/local/go/{{ $.ImageName }}
     - git apply /patches/*.patch
     - cd /usr/local/go/{{ $.ImageName }}/cmd/linstor-affinity-controller

--- a/images/linstor-csi/werf.inc.yaml
+++ b/images/linstor-csi/werf.inc.yaml
@@ -25,7 +25,7 @@ secrets:
 
 shell:
   setup:
-    - apk add --no-cache git
+    - pm install git
     - cd /usr/local/go/linstor-csi
     - git apply /patches/*.patch
     - cd cmd/linstor-csi

--- a/images/linstor-csi/werf.inc.yaml
+++ b/images/linstor-csi/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 git:
   - url: {{ $.Root.SOURCE_REPO }}/linbit/linstor-csi
@@ -39,7 +39,7 @@ shell:
 {{- $csiBinariesXfsprogs  := "/usr/lib64/xfsprogs/xfs_scrub_fail /usr/sbin/fsck.xfs /usr/sbin/mkfs.xfs /usr/sbin/xfs_* /usr/share/xfsprogs/mkfs/* " }}
 {{- $csiBinariesUtilLinux := "/usr/sbin/blkid /usr/sbin/blockdev" }}
 image: {{ $.ImageName }}-binaries-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 git:
   - add: /tools/dev_images/additional_tools/alt/binary_replace.sh
@@ -63,7 +63,7 @@ shell:
     - ln -sf /proc/mounts /relocate/etc/mtab
 ---
 image: {{ $.ImageName }}-distroless-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 shell:
   beforeInstall:
@@ -83,7 +83,7 @@ shell:
     - echo "deckhouse:!::0:::::" >> /relocate/etc/shadow
 ---
 image: {{ $.ImageName }}-distroless
-from: {{ $.Root.BASE_SCRATCH }}
+from: {{ index $.Images "builder/scratch" }}
 final: false
 import:
   - image: {{ $.ImageName }}-distroless-artifact

--- a/images/linstor-drbd-wait/werf.inc.yaml
+++ b/images/linstor-drbd-wait/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-src-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -21,7 +21,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 import:
@@ -47,7 +47,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-distroless-artifact
-from: {{ $.Root.BASE_ALT }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 shell:
   beforeInstall:
@@ -68,7 +68,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-distroless
-from: {{ $.Root.BASE_SCRATCH }}
+from: {{ index $.Images "builder/scratch" }}
 final: false
 import:
   - image: {{ $.ImageName }}-distroless-artifact

--- a/images/linstor-scheduler-extender/werf.inc.yaml
+++ b/images/linstor-scheduler-extender/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 git:
@@ -56,7 +56,7 @@ shell:
     - chmod +x /{{ $.ImageName }}
 ---
 image: {{ $.ImageName }}
-from: {{ $.Root.BASE_SCRATCH }}
+from: {{ index $.Images "builder/scratch" }}
 
 import:
   - image: {{ $.ImageName }}-golang-artifact

--- a/images/linstor-scheduler-extender/werf.inc.yaml
+++ b/images/linstor-scheduler-extender/werf.inc.yaml
@@ -40,7 +40,7 @@ secrets:
 
 shell:
   beforeSetup:
-    - apk add --no-cache git
+    - pm install git
     - cd /usr/local/go/stork
     - '[ -d "/patches/stork/new-files" ] && cp -frp /patches/stork/new-files/* /usr/local/go/stork/'
     - git apply /patches/stork/*.patch

--- a/images/linstor-server/werf.inc.yaml
+++ b/images/linstor-server/werf.inc.yaml
@@ -17,7 +17,7 @@
 ---
 # build linstor-server packages
 image: {{ $.ImageName }}-server-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -87,7 +87,7 @@ shell:
     # linstor-satellite-1.24.2-1.noarch.rpm
 ---
 image: {{ $.ImageName }}-client-artifact
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -187,7 +187,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-k8s-await-election-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 git:
@@ -219,7 +219,7 @@ shell:
 ---
 # main image based on AltLinux for now because we need bash and other tools
 image: {{ $.ImageName }}
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 git:
   - add: /images/{{ $.ImageName }}
     to: /utils

--- a/images/linstor-server/werf.inc.yaml
+++ b/images/linstor-server/werf.inc.yaml
@@ -212,7 +212,7 @@ git:
         - "**/*"
 shell:
   setup:
-    - apk add --no-cache git make
+    - pm install git make
     - cd /usr/local/go/k8s-await-election
     # apply git patches to upstream's code
     - |

--- a/images/linstor-server/werf.inc.yaml
+++ b/images/linstor-server/werf.inc.yaml
@@ -137,7 +137,13 @@ shell:
 
     # patch sdist to do not replace - with _ or RPM build will fail
     # - sed -i "s/canonicalize_name(name).replace('-', '_')/canonicalize_name(name)/g" /usr/lib64/python3/site-packages/setuptools/_distutils/dist.py
-    - sed -i "s/canonicalize_name(self.get_name()).replace('-', '_')/canonicalize_name(self.get_name())/g" /usr/lib64/python3/site-packages/setuptools/_core_metadata.py
+    - |
+      for f in /usr/lib64/python3/site-packages/setuptools/_core_metadata.py \
+               /usr/lib/python3/site-packages/setuptools/_core_metadata.py; do
+        if [ -f "${f}" ]; then
+          sed -i "s/canonicalize_name(self.get_name()).replace('-', '_')/canonicalize_name(self.get_name())/g" "${f}"
+        fi
+      done
 
     # make .rpm package
     # make only spec before building RPM

--- a/images/linstor-wait-until/werf.inc.yaml
+++ b/images/linstor-wait-until/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 git:
@@ -39,7 +39,7 @@ shell:
     - chmod +x /{{ $.ImageName }}
 ---
 image: {{ $.ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 import:
   - image: {{ $.ImageName }}-golang-artifact

--- a/images/linstor-wait-until/werf.inc.yaml
+++ b/images/linstor-wait-until/werf.inc.yaml
@@ -30,7 +30,7 @@ secrets:
 
 shell:
   setup:
-    - apk add --no-cache git
+    - pm install git
     - cd /usr/local/go/{{ $.ImageName }}
     - git apply /patches/*.patch
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download

--- a/images/metadata-backup/werf.inc.yaml
+++ b/images/metadata-backup/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: metadata-backup
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 git:
   - add: /images/metadata-backup/backup.py
     to: /backup.py

--- a/images/semver/werf.inc.yaml
+++ b/images/semver/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-artifact
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 final: false
 
 git:
@@ -15,7 +15,7 @@ shell:
     - mv semver-tool-{{ include "get_oss_version_by_id" (list "SEMVER_TOOL" $.Root) }}/src/semver /d8-semver
 ---
 image: {{ $.ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 import:
   - image: {{ $.ImageName }}-artifact

--- a/images/service-scripts/werf.inc.yaml
+++ b/images/service-scripts/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-artifact
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 final: false
 
 git:
@@ -22,7 +22,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 import:
   - image: {{ $.ImageName }}-artifact

--- a/images/spaas/werf.inc.yaml
+++ b/images/spaas/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 git:
   - url: {{ $.Root.SOURCE_REPO }}/LINBIT/saas
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ImageName }}
 # we must base on ALTLinux because SPAAS generates kernel patches for DRBD. So we need same kernel as in DRBD image and some build tools
-from: {{ $.Root.BASE_ALT_P11 }}
+from: {{ index $.Images "builder/golang-alt" }}
 
 import:
   - image: {{ $.ImageName }}-golang-artifact

--- a/images/webhooks/werf.inc.yaml
+++ b/images/webhooks/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}-src-artifact
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -21,7 +21,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}-golang-artifact
-fromImage: builder/golang-alpine
+from: {{ index $.Images "builder/golang" }}
 final: false
 
 import:
@@ -47,7 +47,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 import:
   - image: {{ $.ImageName }}-golang-artifact


### PR DESCRIPTION
## Description

Migrate module build to `deckhouse/container-base/base-images` **v1.0.51**:

- Bump `BASE_IMAGES_VERSION` from `v0.5.79` to `v1.0.51` in dev/prod GitHub Actions workflows; fix package URL to `deckhouse/container-base/base-images`.
- Remove intermediate werf artifacts for base images and hardcoded `BASE_*` registry refs from `.werf/consts.yaml`; use `from: {{ index $.Images "…" }}` directly.
- Update all 15 module images to reference `builder/golang`, `builder/golang-alt`, `builder/distroless`, `builder/alpine`, `builder/scratch` from the catalog.
- Add `update-base-images-versions` Makefile target, `base_images.yml` to `.gitignore`, `no-cyrillic` dmtlint exclusion for `hack/`.

RPM/ALT builds (`linstor-server`, `drbd-reactor`, `spaas`, `drbd`) and custom distroless chains (`linstor-csi`, `linstor-drbd-wait`) are unchanged in build logic — only base image references were updated.

## Why do we need it, and what problem does it solve?

The module still used the legacy base-images werf pattern (`fromImage`, intermediate artifacts, hardcoded registry digests in `consts.yaml`). Container-base v1.0.x provides a unified catalog and direct image references. Aligning with other storage modules simplifies maintenance and keeps base image versions in sync.

## What is the expected result?

- CI builds pull base images at `v1.0.51` from the correct GitLab package registry path.
- All module images build successfully with the new werf configuration.
- RPM/ALT runtime images and custom distroless assembly behave as before.
- No functional changes to controller, LINSTOR, or CSI application logic.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.